### PR TITLE
Optim: Split the Algo::Contains method in 2

### DIFF
--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -571,10 +571,16 @@ namespace FileCore {
 
 	struct Algo
 	{
-		template <typename ArrayType, typename ValueType>
-		static bool Contains(const ArrayType& elements, const ValueType& v)
+		template <typename ValueType>
+		static bool Contains(const Array<ValueType>& elements, const ValueType& v)
 		{
 			return std::find(elements.begin(), elements.end(), v) != elements.end();
+		}
+
+		template <typename KeyType>
+		static bool Contains(const HashSet<KeyType>& elements, const KeyType& v)
+		{
+			return elements.find(v) != elements.end();
 		}
 
 		template <typename ArrayType, typename Predicate>


### PR DESCRIPTION
Optim: Split the Algo::Contains method in 2, using std::find for Arrays but the .find method on HashSet type.

This significantly speeds up the Contains ops in the last loop of DepotOperations::SyncCommand

https://github.com/microsoft/p4vfs/blob/ef246c03b0c8f40128a576c160eea450c71642dc/source/P4VFS.Core/Source/DepotOperations.cpp#L845