### PR TITLE
1.26.0.0 release

### DIFF
--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -28,7 +28,7 @@ jobs:
   setup:
     runs-on: [windows-latest]
     outputs:
-      matrix: ${{ steps.configure.outputs.matrix }}
+      matrix: '[Debug, Release]'
     steps:
       - id: configure
         run: echo "matrix=$env:BUILD_CONFIGURATIONS" >> $GITHUB_OUTPUT

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -24,12 +24,26 @@ permissions:
   contents: read
 
 jobs:
+  setup:
+    runs-on: [windows-latest]
+    outputs:
+      configs: ${{ steps.configure.outputs.configs }}
+    steps:
+      - id: configure
+        run: |
+          if ($env:GITHUB_REF_NAME -match "dev/.+") {
+              Write-Output "::set-output name=configs::[DebugDev,ReleaseDev]"
+          } else {
+              Write-Output "::set-output name=configs::[Debug,Release]"
+          }
+
   build:
     runs-on: ${{matrix.os}}
+    needs: setup
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ startsWith(github.ref_name, 'dev/') && 'DebugDev,ReleaseDev' || 'Debug,Release' }}
+        configuration: ${{ fromJSON(needs.setup.outputs.configs) }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON(needs.setup.outputs.matrix) }}
+        configuration: ${{ fromJSON('[Debug, Release]') }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -31,9 +31,7 @@ jobs:
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - id: configure
-        run: echo "matrix=$input"
-        env:
-          input: ${{ env.BUILD_CONFIGURATIONS }}
+        run: echo "matrix=$env:BUILD_CONFIGURATIONS"
 
   build:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -35,6 +35,7 @@ jobs:
 
   build:
     runs-on: ${{matrix.os}}
+    needs: setup
     strategy:
       matrix:
         os: [windows-latest]

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{fromJSON(env.BUILD_CONFIGURATIONS)}}
+        configuration: ${{ fromJSON( ${{ env.BUILD_CONFIGURATIONS }} ) }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -25,12 +25,23 @@ permissions:
   contents: read
 
 jobs:
+  setup:
+    runs-on: ${{matrix.os}}
+    outputs:
+      matrix: ${{ steps.configure.outputs.matrix }}
+    steps:
+      - id: configure
+        run: |
+          echo "::set-output name=matrix::$input"
+        env:
+          input: ${{ env.BUILD_CONFIGURATIONS }}
+
   build:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON(vars.BUILD_CONFIGURATIONS) }}
+        configuration: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON(env.BUILD_CONFIGURATIONS) }}
+        configuration: ${{ fromJSON(vars.BUILD_CONFIGURATIONS) }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: [DebugDev, ReleaseDev]
+        configuration: ${{ fromJson(startsWith(github.ref_name, 'dev/') && '[DebugDev,ReleaseDev]' || '[Debug,Release]') }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -24,26 +24,12 @@ permissions:
   contents: read
 
 jobs:
-  setup:
-    runs-on: [windows-latest]
-    outputs:
-      configs: ${{ steps.configure.outputs.configs }}
-    steps:
-      - id: configure
-        run: |
-          if ($env:GITHUB_REF_NAME -match "dev/.+") {
-              Write-Output "::set-output name=configs::[DebugDev,ReleaseDev]"
-          } else {
-              Write-Output "::set-output name=configs::[Debug,Release]"
-          }
-
   build:
     runs-on: ${{matrix.os}}
-    needs: setup
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON(needs.setup.outputs.configs) }}
+        configuration: [Debug, Release]
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON('[Debug, Release]') }}
+        configuration: ${{ fromJSON("[Debug, Release]") }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -31,8 +31,7 @@ jobs:
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - id: configure
-        run: |
-          echo "::set-output name=matrix::$input"
+        run: echo "matrix=$input"
         env:
           input: ${{ env.BUILD_CONFIGURATIONS }}
 

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -15,6 +15,7 @@ on:
 env:
   SOLUTION_FILE_PATH: source/P4VFS.sln
   BUILD_PLATFORM: x64
+  BUILD_CONFIGURATIONS: '[Debug, Release]'
 
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -29,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: [Debug, Release]
+        configuration: ${{fromJSON(env.BUILD_CONFIGURATIONS)}}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJson(startsWith(github.ref_name, 'dev/') && '[DebugDev,ReleaseDev]' || '[Debug,Release]') }}
+        configuration: ${{ startsWith(github.ref_name, 'dev/') && 'DebugDev,ReleaseDev' || 'Debug,Release' }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: [Debug, Release]
+        configuration: [DebugDev, ReleaseDev]
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -15,7 +15,6 @@ on:
 env:
   SOLUTION_FILE_PATH: source/P4VFS.sln
   BUILD_PLATFORM: x64
-  BUILD_CONFIGURATIONS: '[Debug, Release]'
 
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -25,21 +24,12 @@ permissions:
   contents: read
 
 jobs:
-  setup:
-    runs-on: [windows-latest]
-    outputs:
-      matrix: '[Debug, Release]'
-    steps:
-      - id: configure
-        run: echo "matrix=$env:BUILD_CONFIGURATIONS" >> $GITHUB_OUTPUT
-
   build:
     runs-on: ${{matrix.os}}
-    needs: setup
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON("[Debug, Release]") }}
+        configuration: [Debug, Release]
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:
       - id: configure
-        run: echo "matrix=$env:BUILD_CONFIGURATIONS"
+        run: echo "matrix=$env:BUILD_CONFIGURATIONS" >> $GITHUB_OUTPUT
 
   build:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: fromJSON( ${{ env.BUILD_CONFIGURATIONS }} )
+        configuration: ${{ fromJSON(env.BUILD_CONFIGURATIONS) }}
 
     steps:
     - name: Set image info in env

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: ${{matrix.os}}
+    runs-on: [windows-latest]
     outputs:
       matrix: ${{ steps.configure.outputs.matrix }}
     steps:

--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        configuration: ${{ fromJSON( ${{ env.BUILD_CONFIGURATIONS }} ) }}
+        configuration: fromJSON( ${{ env.BUILD_CONFIGURATIONS }} )
 
     steps:
     - name: Set image info in env

--- a/external/P4VFS/P4VFS.Module.cs
+++ b/external/P4VFS/P4VFS.Module.cs
@@ -11,7 +11,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class P4vfsModule : Module
 	{
-		private const string P4VFS_SIGNED_VERSION = "1.25.0.0";
+		private const string P4VFS_SIGNED_VERSION = "1.26.0.0";
 		private const string P4VFS_SIGNED_ARTIFACTS_URL = "https://github.com/microsoft/p4vfs/releases/download";
 
 		public override string Name

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -5,6 +5,9 @@ Version [1.26.0.0]
 * Refactor of perforce client login operations to support common forms of password and
   SSO login. This includes password auth, classic P4LOGINSSO client script auth, and server 
   auth extensions such as Helix Authentication Service.
+* Fixing service process launch as impersonated user to include the user's profile environment.
+  This allows the service's interactive password prompt, or browser authentication, to execute
+  with expected user environment variables.
 
 Version [1.25.1.0]
 * Addition of new "hydrate" command as synonym for "resident -x". Moved the implementation into

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -3,8 +3,8 @@ Microsoft P4VFS Release Notes
 Version [1.26.0.0]
 * Driver using officially allocated FSFilter HSM altitude of 189700
 * Refactor of perforce client login operations to support common forms of password and
-  SSO login. This includes password auth, classic P4LOGINSSO client script auth, as well
-  and server auth extensions such as Helix Authentication Server for MFA. 
+  SSO login. This includes password auth, classic P4LOGINSSO client script auth, and server 
+  auth extensions such as Helix Authentication Service.
 
 Version [1.25.1.0]
 * Addition of new "hydrate" command as synonym for "resident -x". Moved the implementation into

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,8 @@
 Microsoft P4VFS Release Notes
 
+Version [1.26.0.0]
+* Driver using officially allocated FSFilter HSM altitude of 189700
+
 Version [1.25.1.0]
 * Addition of new "hydrate" command as synonym for "resident -x". Moved the implementation into
   C++ and now using a single fstat command instead of a files & where command.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -2,6 +2,9 @@ Microsoft P4VFS Release Notes
 
 Version [1.26.0.0]
 * Driver using officially allocated FSFilter HSM altitude of 189700
+* Refactor of perforce client login operations to support common forms of password and
+  SSO login. This includes password auth, classic P4LOGINSSO client script auth, as well
+  and server auth extensions such as Helix Authentication Server for MFA. 
 
 Version [1.25.1.0]
 * Addition of new "hydrate" command as synonym for "resident -x". Moved the implementation into

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -1016,7 +1016,7 @@ Available commands:
 				using (DepotClient depotClient = new DepotClient())
 				{
 					depotClient.Unattended = true;
-					return depotClient.Connect(_P4Port, _P4Client, _P4User, _P4Directory, _P4Passwd, _P4Host) && depotClient.Login(_P4Passwd);
+					return depotClient.Connect(_P4Port, _P4Client, _P4User, _P4Directory, _P4Passwd, _P4Host) && depotClient.Login((_) => _P4Passwd);
 				}
 			};
 

--- a/source/P4VFS.Core/Include/DepotClient.h
+++ b/source/P4VFS.Core/Include/DepotClient.h
@@ -143,18 +143,6 @@ namespace P4 {
 		P4VFS_CORE_API static bool IsKnown(const DepotString& name);
 	};
 
-	struct DepotClientImpersonationScope : FileCore::NonCopyable<DepotClientImpersonationScope>
-	{
-	public:
-		DepotClientImpersonationScope(FDepotClient& client);
-		virtual ~DepotClientImpersonationScope();
-		HRESULT Status() const { return m_status; }
-
-	private:
-		HRESULT m_status;
-		bool m_impersonated;
-	};
-
 }}}
 
 #pragma managed(pop)

--- a/source/P4VFS.Core/Include/DepotClient.h
+++ b/source/P4VFS.Core/Include/DepotClient.h
@@ -16,8 +16,7 @@ namespace P4 {
 
 	typedef std::shared_ptr<struct FDepotClient> DepotClient;
 	typedef std::function<void(LogChannel::Enum channel, const char* severity, const char* text)> FDepotClientLogCallback;
-	typedef FDepotClientLogCallback FOnErrorCallback;
-	typedef FDepotClientLogCallback FOnMessageCallback;
+	typedef std::shared_ptr<FDepotClientLogCallback> DepotClientLogCallback;
 
 	struct FDepotClient
 	{
@@ -34,7 +33,7 @@ namespace P4 {
 		P4VFS_CORE_API bool IsConnectedClient();
 
 		P4VFS_CORE_API bool IsLoginRequired();
-		P4VFS_CORE_API bool Login(const DepotString& passwd);
+		P4VFS_CORE_API bool Login(DepotClientPromptCallback prompt);
 		P4VFS_CORE_API bool Login();
 
 		P4VFS_CORE_API DepotResult Trust();
@@ -61,10 +60,10 @@ namespace P4 {
 		template <typename Result = DepotResult>
 		Result Run(const DepotString& name, const DepotStringArray& args = DepotStringArray());
 	
-		virtual bool OnRequestPassword(DepotString& passwd);
 		virtual void OnErrorPause(const char* message);
 		virtual void OnErrorCallback(LogChannel::Enum channel, const char* severity, const char* text);
 		virtual void OnMessageCallback(LogChannel::Enum channel, const char* severity, const char* text);
+		virtual DepotString OnPromptCallback(const DepotCommand* command, const char* message);
 
 		P4VFS_CORE_API LogDevice* Log();
 		P4VFS_CORE_API void Log(LogChannel::Enum channel, const DepotString& text);
@@ -93,15 +92,14 @@ namespace P4 {
 		P4VFS_CORE_API DepotString GetEnvImpersonated(const char* name) const;
 		P4VFS_CORE_API WString GetEnvImpersonatedW(const char* name) const;
 
-		P4VFS_CORE_API void SetErrorCallback(FOnErrorCallback* callback);
-		P4VFS_CORE_API void SetMessageCallback(FOnMessageCallback* callback);
+		P4VFS_CORE_API void SetErrorCallback(DepotClientLogCallback callback);
+		P4VFS_CORE_API void SetMessageCallback(DepotClientLogCallback callback);
 
 	protected:
 		bool LoginUsingConfig();
-		bool LoginUsingSSO();
 		bool LoginUsingClientOwner();
-		bool LoginUsingImpersonation();
 		bool LoginUsingInteractiveSession();
+		bool RequestInteractivePassword(DepotString& passwd);
 
 	private:
 		struct Api;
@@ -143,6 +141,18 @@ namespace P4 {
 		P4VFS_CORE_API static void	Unset(const DepotString& name);
 		P4VFS_CORE_API static bool IsSet(const DepotString& name);
 		P4VFS_CORE_API static bool IsKnown(const DepotString& name);
+	};
+
+	struct DepotClientImpersonationScope : FileCore::NonCopyable<DepotClientImpersonationScope>
+	{
+	public:
+		DepotClientImpersonationScope(FDepotClient& client);
+		virtual ~DepotClientImpersonationScope();
+		HRESULT Status() const { return m_status; }
+
+	private:
+		HRESULT m_status;
+		bool m_impersonated;
 	};
 
 }}}

--- a/source/P4VFS.Core/Include/DepotClientCache.h
+++ b/source/P4VFS.Core/Include/DepotClientCache.h
@@ -20,6 +20,7 @@ namespace P4 {
 		void GarbageCollect(int64_t timeoutSeconds);
 		
 		size_t GetFreeCount() const;
+		static int64_t GetIdleTimeoutSeconds();
 
 	private:
 		static DepotString CreateKey(const DepotConfig& config);
@@ -27,7 +28,6 @@ namespace P4 {
 	private:
 		typedef UnorderedMultiMap<DepotString, DepotClient, StringInfo::Hash, StringInfo::EqualInsensitive> FreeMapType;
 
-		const int64_t m_KeepAliveSeconds;
 		CriticalSection m_FreeMapLock;
 		FreeMapType* m_FreeMap;
 	};

--- a/source/P4VFS.Core/Include/DepotCommand.h
+++ b/source/P4VFS.Core/Include/DepotCommand.h
@@ -8,6 +8,9 @@ namespace Microsoft {
 namespace P4VFS {
 namespace P4 {
 
+	typedef std::function<DepotString(const DepotString&)> FDepotClientPromptCallback;
+	typedef std::shared_ptr<FDepotClientPromptCallback> DepotClientPromptCallback;
+
 	struct DepotCommand
 	{
 		struct Flags { enum Enum {
@@ -28,8 +31,8 @@ namespace P4 {
 		DepotString m_Name;
 		DepotStringArray m_Args;
 		DepotString m_Input;
-		DepotString m_Prompt;
 		Flags::Enum m_Flags;
+		DepotClientPromptCallback m_Prompt;
 	};
 
 	struct IDepotClientCommand

--- a/source/P4VFS.Core/Include/SettingManager.h
+++ b/source/P4VFS.Core/Include/SettingManager.h
@@ -30,7 +30,7 @@ namespace FileCore {
 		_N( int32_t,  CreateFileRetryWaitMs,           250 ) \
 		_N( int32_t,  PoolDefaultNumberOfThreads,      8 ) \
 		_N( int32_t,  GarbageCollectPeriodMs,          5*60*1000 ) \
-		_N( int32_t,  DepotClientCacheIdleTimeoutMs,   10*60*1000 ) \
+		_N( int32_t,  DepotClientCacheIdleTimeoutMs,   5*60*1000 ) \
 
 
 	class SettingManager;

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -285,6 +285,16 @@ public:
 		m_Client->OnErrorPause(errBuf);
 	}
 
+	virtual void HandleUrl(const StrPtr* url) override
+	{
+		if (url != nullptr && FileCore::StringInfo::IsNullOrEmpty(url->Text()) == false)
+		{
+			UserContext* context = m_Client->GetUserContext();
+			DepotString cmd = StringInfo::Format("powershell.exe -Command \"&{ Start-Process -FilePath '%s' -Verb runas }\"", url->Text());
+			FileOperations::CreateProcessImpersonated(CSTR_ATOW(cmd), nullptr, FALSE, nullptr, context);
+		}
+	}
+
 	virtual void Diff(FileSys* f1, FileSys* f2, FileSys* fout, int doPage, char* diffFlags, Error* e) override
 	{
 		if (e == nullptr || fout != nullptr)

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -290,7 +290,7 @@ public:
 		if (url != nullptr && FileCore::StringInfo::IsNullOrEmpty(url->Text()) == false)
 		{
 			UserContext* context = m_Client->GetUserContext();
-			DepotString cmd = StringInfo::Format("powershell.exe -Command \"&{ Start-Process -FilePath '%s' -Verb runas }\"", url->Text());
+			DepotString cmd = StringInfo::Format("cmd.exe /c start %s", url->Text());
 			FileOperations::CreateProcessImpersonated(CSTR_ATOW(cmd), nullptr, FALSE, nullptr, context);
 		}
 	}

--- a/source/P4VFS.Core/Source/DepotOperations.cpp
+++ b/source/P4VFS.Core/Source/DepotOperations.cpp
@@ -869,13 +869,13 @@ DepotOperations::SyncCommand(
 		}
 	}
 
-	FDepotClientLogCallback onClientLogCallback = [log](LogChannel::Enum channel, const char* severity, const char* text) -> void
+	DepotClientLogCallback onClientLogCallback = std::make_shared<FDepotClientLogCallback>([log](LogChannel::Enum channel, const char* severity, const char* text) -> void
 	{
 		if (log != nullptr)
 		{
 			log->Write(channel, StringInfo::ToWide(text));
 		}
-	};
+	});
 
 	DepotCommand syncCmd;
 	syncCmd.m_Name = "sync";
@@ -895,8 +895,8 @@ DepotOperations::SyncCommand(
 		syncCmd.m_Flags |= DepotCommand::Flags::UnTagged;
 	}
 
-	depotClient->SetMessageCallback(&onClientLogCallback);
-	depotClient->SetErrorCallback(&onClientLogCallback);
+	depotClient->SetMessageCallback(onClientLogCallback);
+	depotClient->SetErrorCallback(onClientLogCallback);
 	DepotResult syncResult = depotClient->Run(syncCmd);
 	depotClient->SetMessageCallback(nullptr);
 	depotClient->SetErrorCallback(nullptr);

--- a/source/P4VFS.CoreInterop/Include/CoreMarshal.h
+++ b/source/P4VFS.CoreInterop/Include/CoreMarshal.h
@@ -139,6 +139,11 @@ public:
 		return System::Runtime::InteropServices::GCHandle::ToIntPtr(m_hGlobal).ToPointer();
 	}
 
+	System::Object^ Target()
+	{
+		return m_hGlobal.Target;
+	}
+
 private:
 	System::Runtime::InteropServices::GCHandle m_hGlobal;
 };

--- a/source/P4VFS.CoreInterop/Include/DepotClientInterop.h
+++ b/source/P4VFS.CoreInterop/Include/DepotClientInterop.h
@@ -30,7 +30,7 @@ public:
 	System::String^ Name;
 	array<System::String^>^ Args;
 	System::String^ Input;
-	System::String^ Prompt;
+	System::Func<System::String^, System::String^>^ Prompt;
 	DepotCommandFlags Flags;
 };
 
@@ -69,7 +69,7 @@ public:
 
 	bool 
 	Login(
-		System::String^ passwd
+		System::Func<System::String^, System::String^>^ prompt
 		);
 
 	bool 

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
-#define P4VFS_VER_MINOR					25			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_MINOR					26			// Increment this number whenever the driver changes
+#define P4VFS_VER_BUILD					0			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v

--- a/source/P4VFS.Driver/p4vfsflt.inf
+++ b/source/P4VFS.Driver/p4vfsflt.inf
@@ -91,5 +91,5 @@ DriverName              = "p4vfsflt"
 DiskId1                 = "P4VFS Device Installation Disk"
 DefaultInstance         = "P4VFS Instance"
 Instance1.Name          = "P4VFS Instance"
-Instance1.Altitude      = "191024"
+Instance1.Altitude      = "189700"
 Instance1.Flags         = 0x0           ; Allow all attachments

--- a/source/P4VFS.Service/Source/ServiceHost.cpp
+++ b/source/P4VFS.Service/Source/ServiceHost.cpp
@@ -227,8 +227,7 @@ ServiceHost::SrvTickThreadEntry(
 
 	while (WaitForSingleObject(pSrvHost->m_SrvStopEvent, tickPeriodMs()) != WAIT_OBJECT_0)
 	{
-		int64_t timeoutSeconds = std::max<int32_t>(1, FileCore::SettingManager::StaticInstance().DepotClientCacheIdleTimeoutMs.GetValue()/1000);
-		pSrvHost->GarbageCollect(timeoutSeconds);
+		pSrvHost->GarbageCollect(P4::DepotClientCache::GetIdleTimeoutSeconds());
 	}
 
 	return 0;

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -554,6 +554,18 @@ namespace Microsoft.P4VFS.UnitTest
 			return serviceClient.GetServiceStatus()?.LastRequestTime ?? DateTime.MinValue;
 		}
 
+		public int GetServiceIdleConnectionCount()
+		{
+			return ProcessInfo.ExecuteWaitOutput(P4Exe, String.Format("{0} monitor show -a -l", ClientConfig), echo:true).Lines
+				.Count(line => Regex.IsMatch(line, @"^\s*(?<id>\d+)\s+(?<status>\w)\s+(?<user>\S+)\s+(?<duration>\S+)\s+(IDLE)"));
+		}
+
+		public bool ServiceGarbageCollect()
+		{
+			Extensions.SocketModel.SocketModelClient service = new Extensions.SocketModel.SocketModelClient(); 
+			return service.GarbageCollect();
+		}
+
 		public FileDifferenceSummary DiffAgainstWorkspace(string fileSpec)
 		{
 			FileDifferenceSummary summary = new FileDifferenceSummary();	

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -249,6 +249,12 @@ namespace Microsoft.P4VFS.UnitTest
 			AssertRetry(() => VirtualFileSystem.IsVirtualFileSystemAvailable(), message:"IsVirtualFileSystemAvailable");
 			ServiceSettings.Reset();
 			InteractiveOverridePasswd = null;
+
+			if (String.IsNullOrEmpty(config.Passwd))
+			{
+				config.Passwd = UnitTestServer.GetUserP4Passwd(config.User);
+				Assert(String.IsNullOrEmpty(config.Passwd) == false);
+			}
 			
 			using (DepotClient depotClient = new DepotClient())
 			{

--- a/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
@@ -428,6 +428,9 @@ namespace Microsoft.P4VFS.UnitTest
 			// Logout and interactive login from service with the correct password
 			Assert(p4logout());
 			InteractiveOverridePasswd = depotPasswd;
+			Extensions.SocketModel.SocketModelClient service = new Extensions.SocketModel.SocketModelClient(); 
+			Assert(ServiceGarbageCollect());
+			Assert(GetServiceIdleConnectionCount() == 0);
 			Assert(ReconcilePreview(depotSyncPath).Any() == false);
 			InteractiveOverridePasswd = null;
 		}
@@ -1435,6 +1438,9 @@ namespace Microsoft.P4VFS.UnitTest
 
 			string clientRoot = GetClientRoot();
 			string configFileName = ".p4vfsconfig";
+			string environmentUser = "northamerica\\quebec";
+			string environmentClient = "quebec-pc-depot";
+			string environmentPasswd = UnitTestServer.GetUserP4Passwd(environmentUser);
 			string rootFolder = clientRoot;
 			string subFolder = Path.Combine(rootFolder, "depot");
 			AssertLambda(() => FileUtilities.CreateDirectory(subFolder));
@@ -1446,8 +1452,8 @@ namespace Microsoft.P4VFS.UnitTest
 					depotClient.Unattended = true;
 					// Connect from environment without P4CONFIG
 					Assert(depotClient.Connect(directoryPath:rootFolder));
-					Assert(depotClient.ConnectionClient().Client == "quebec-pc-depot");
-					Assert(depotClient.Info().UserName == "northamerica\\quebec");
+					Assert(depotClient.ConnectionClient().Client == environmentClient);
+					Assert(depotClient.Info().UserName == environmentUser);
 					Assert(ProcessInfo.ExecuteWaitOutput(P4vfsExe, "info", directory:rootFolder, echo:true, log:true).Lines.Contains("P4 UserName: northamerica\\quebec"));
 				}}
 			};
@@ -1472,9 +1478,9 @@ namespace Microsoft.P4VFS.UnitTest
 				}}
 			};
 
-			using (new SetEnvironmentVariableScope("P4USER", "northamerica\\quebec")) {
-			using (new SetEnvironmentVariableScope("P4CLIENT", "quebec-pc-depot")) {
-			using (new SetEnvironmentVariableScope("P4PASSWD", UnitTestServer.DefaultP4Passwd)) {
+			using (new SetEnvironmentVariableScope("P4USER", environmentUser)) {
+			using (new SetEnvironmentVariableScope("P4CLIENT", environmentClient)) {
+			using (new SetEnvironmentVariableScope("P4PASSWD", environmentPasswd)) {
 			using (new SetEnvironmentVariableScope("P4PORT", _P4Port)) 
 			{
 				emptyConfigTest();
@@ -1811,11 +1817,6 @@ namespace Microsoft.P4VFS.UnitTest
 		public void DepotClientCacheIdleTimeoutTest()
 		{
 			WorkspaceReset();
-			Func<int> getIdleConnectionCount = () =>
-			{
-				return ProcessInfo.ExecuteWaitOutput(P4Exe, String.Format("{0} monitor show -a -l", ClientConfig), echo:true).Lines
-					.Count(line => Regex.IsMatch(line, @"^\s*(?<id>\d+)\s+(?<status>\w)\s+(?<user>\S+)\s+(?<duration>\S+)\s+(IDLE)"));
-			};
 
 			Action<Extensions.SocketModel.SocketModelClient, DepotConfig> assertSyncAndReconcile = (service, config) =>
 			{
@@ -1826,28 +1827,29 @@ namespace Microsoft.P4VFS.UnitTest
 
 				// Reconcile the folder using p4.exe. There will be one or more cached service connections
 				Assert(ReconcilePreview(depotFolder).Any() == false);
-				Assert(getIdleConnectionCount() > 1);
+				Assert(GetServiceIdleConnectionCount() > 1);
 			};
 
 			// There should be no idle connections from any process, including this process
-			Assert(getIdleConnectionCount() == 0);
+			Assert(GetServiceIdleConnectionCount() == 0);
 			using (DepotClient depotClient = new DepotClient())
 			{
+				Extensions.SocketModel.SocketModelClient service = new Extensions.SocketModel.SocketModelClient(); 
+
 				// Open a single idle connection
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
-				Assert(getIdleConnectionCount() == 1);
-
-				Extensions.SocketModel.SocketModelClient service = new Extensions.SocketModel.SocketModelClient(); 
-				Assert(service.GarbageCollect());
-				Assert(getIdleConnectionCount() == 1);
+				Assert(GetServiceIdleConnectionCount() == 1);
+				
+				Assert(ServiceGarbageCollect());
+				Assert(GetServiceIdleConnectionCount() == 1);
 
 				// Sync and reconcile to open some cached service connections
 				assertSyncAndReconcile(service, depotClient.Config());
-				Assert(getIdleConnectionCount() > 1);
+				Assert(GetServiceIdleConnectionCount() > 1);
 
 				// Close the idle service connections with a GC
-				Assert(service.GarbageCollect());
-				Assert(getIdleConnectionCount() == 1);
+				Assert(ServiceGarbageCollect());
+				Assert(GetServiceIdleConnectionCount() == 1);
 
 				// Write a temporary PublicSettingsFilePath settings file with very short GC timeout
 				using (new LocalSettingScope(nameof(SettingManager.GarbageCollectPeriodMs), "100")) {
@@ -1859,30 +1861,30 @@ namespace Microsoft.P4VFS.UnitTest
 
 					// Restart the service to load our new settings
 					ServiceRestart();
-					Assert(getIdleConnectionCount() == 1);
+					Assert(GetServiceIdleConnectionCount() == 1);
 
 					Assert(service.GetServiceSetting(nameof(SettingManager.GarbageCollectPeriodMs)).ToInt32() == SettingManager.GarbageCollectPeriodMs);
 					Assert(service.GetServiceSetting(nameof(SettingManager.DepotClientCacheIdleTimeoutMs)).ToInt32() == SettingManager.DepotClientCacheIdleTimeoutMs);
 
 					// Sync and reconcile to open some cached service connections
 					assertSyncAndReconcile(service, depotClient.Config());
-					Assert(getIdleConnectionCount() > 1);
+					Assert(GetServiceIdleConnectionCount() > 1);
 
 					// Wait at least DepotClientCacheIdleTimeoutMs for the service connections to be closed
-					AssertRetry(() => getIdleConnectionCount() == 1, "Waiting for GC", retryWait:500, limitWait:8000);
+					AssertRetry(() => GetServiceIdleConnectionCount() == 1, "Waiting for GC", retryWait:500, limitWait:8000);
 				}}}
 			
 				// Restart the service to load base settings again
 				Assert(File.Exists(VirtualFileSystem.PublicSettingsFilePath) == false);
 				ServiceRestart();
-				Assert(getIdleConnectionCount() == 1);
+				Assert(GetServiceIdleConnectionCount() == 1);
 
 				Assert(service.GetServiceSetting(nameof(SettingManager.GarbageCollectPeriodMs)).ToInt32() == SettingManager.GarbageCollectPeriodMs);
 				Assert(service.GetServiceSetting(nameof(SettingManager.DepotClientCacheIdleTimeoutMs)).ToInt32() == SettingManager.DepotClientCacheIdleTimeoutMs);
 			}
 		}
 
-		[TestMethod, Priority(33), TestRemote]
+		[TestMethod, Priority(33)]
 		public void DepotOperationsReconfigTest()
 		{
 			WorkspaceReset();
@@ -1936,11 +1938,11 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(System.Net.IPAddress.TryParse(portIP, out System.Net.IPAddress _) == true);
 
 				DepotConfig targetConfig = new DepotConfig();
-				targetConfig.Port = String.Format("{0}:{1}", portName == "localhost" ? "" : portIP, portNumber);
+				targetConfig.Port = String.Format("{0}:{1}", portIP, portNumber);
 				targetConfig.Client = sourceConfig.Client;
 				targetConfig.User = sourceConfig.User;
-				targetConfig.Passwd = UnitTestServer.GetUserP4Passwd(sourceConfig.User);
 
+				InteractiveOverridePasswd = UnitTestServer.GetUserP4Passwd(_P4User);
 				using (DepotClient targetDepotClient = new DepotClient())
 				{
 					Assert(targetDepotClient.Connect(targetConfig));
@@ -1960,6 +1962,7 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 
 				Assert(ReconcilePreview(clientRoot).Any() == false);
+				InteractiveOverridePasswd = null;
 			}
 		}
 	}

--- a/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
@@ -415,7 +415,7 @@ namespace Microsoft.P4VFS.UnitTest
 			using (DepotClient depotClient = new DepotClient())
 			{
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User, depotPasswd:depotPasswd));
-				Assert(depotClient.Login(depotPasswd));
+				Assert(depotClient.Login((_) => depotPasswd));
 			}
 		}
 

--- a/source/P4VFS.UnitTest/Source/UnitTestRemote.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestRemote.cs
@@ -55,7 +55,7 @@ namespace Microsoft.P4VFS.UnitTest
 				Port = String.Format("{0}:{1}", serverPortIPAddress, serverPortNumber), 
 				Client = _P4Client, 
 				User = _P4User,
-				Passwd = "Password1",
+				Passwd = UnitTestServer.GetUserP4Passwd(_P4User)
 			};
 
 			Assert(remoteTests.Count > 0);
@@ -68,7 +68,7 @@ namespace Microsoft.P4VFS.UnitTest
 
 		private int RemoteExecuteWait(string cmd, bool admin=false, bool shell=false, bool copy=false, StringBuilder stdout=null)
 		{
-			return ProcessInfo.RemoteExecuteWait(cmd, RemoteHost, RemoteUser, RemotePasswd, admin:admin, shell:shell, copy:copy, stdout:stdout);
+			return ProcessInfo.RemoteExecuteWait(cmd, RemoteHost, RemoteUser, RemotePasswd, admin:admin, shell:shell, copy:copy, stdout:stdout, interactive:true);
 		}
 
 		private string GetRequiredEnvironmentVariable(string name)

--- a/source/P4VFS.UnitTest/Source/UnitTestServer.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestServer.cs
@@ -531,12 +531,15 @@ namespace Microsoft.P4VFS.UnitTest
 
 		public static string GetUserP4Passwd(string username)
 		{
-			return LoadServerRecipeXmlDocument()
+			string passwd = LoadServerRecipeXmlDocument()
 				.SelectNodes("./server/user")
 				.OfType<XmlElement>()
 				.Where(u => u.GetAttribute("name") == username)
 				.Select(u => u.GetAttribute("password"))
-				.FirstOrDefault() ?? DefaultP4Passwd;
+				.FirstOrDefault()?.NullIfEmpty() ?? DefaultP4Passwd;
+			
+			Assert(String.IsNullOrEmpty(passwd) == false);
+			return passwd;
 		}
 
 		public static string GetServerLoginSSOFilePath(string p4Port = null)

--- a/source/P4VFS.UnitTest/Source/UnitTestServer.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestServer.cs
@@ -116,7 +116,7 @@ namespace Microsoft.P4VFS.UnitTest
 					DepotResultView userResult = adminClient.Run(new DepotCommand{ Name="user", Args=new[]{"-i", "-f"}, Input=userSpec }).ToView();
 					Assert(userResult.HasError == false);
 					Assert(adminClient.Users().Nodes.Any(n => n.User == _P4User));
-					Assert(adminClient.Run(new DepotCommand{ Name="passwd", Args=new[]{userName}, Prompt=password }).HasError == false);
+					Assert(adminClient.Run(new DepotCommand{ Name="passwd", Args=new[]{userName}, Prompt=(_) => password }).HasError == false);
 
 					using (DepotClient userClient = new DepotClient())
 					{


### PR DESCRIPTION
Version [1.26.0.0]
* Driver using officially allocated FSFilter HSM altitude of 189700
* Refactor of perforce client login operations to support common forms of password and
  SSO login. This includes password auth, classic P4LOGINSSO client script auth, and server 
  auth extensions such as Helix Authentication Service.
* Fixing service process launch as impersonated user to include the user's profile environment.
  This allows the service's interactive password prompt, or browser authentication, to execute
  with expected user environment variables.