### PR TITLE
1.26.1.0

### DIFF
--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,11 @@
 Microsoft P4VFS Release Notes
 
+Version [1.26.1.0]
+* Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.
+  Additional unit test for handling file paths containing common french accent marks.
+* Fixing execution of remote unit tests requiring an installed p4.exe instead of using
+  the included P4VFS external binaries
+
 Version [1.26.0.0]
 * Driver using officially allocated FSFilter HSM altitude of 189700
 * Refactor of perforce client login operations to support common forms of password and

--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -115,6 +115,18 @@ namespace FileCore {
 		return (T)((((size_t)Ptr + Alignment - 1) / Alignment) * Alignment);
 	}
 
+	// P4VFS string encoding
+	//
+	// AString 
+	//     Otherwise referred to as "Ansi" string, but is not strictly ANSI. We use the term to refer to the 
+	//     CP-1252 single-byte encoding. This should not be confused as a UTF-8 multi-byte encoding. Unless
+	//     otherwise specified, all char* strings in P4VFS are assumed to be AString.
+	//
+	// WString
+	//     Otherwise referred to as "Wide" string. This is UTF-16 multi-byte encoding. Windows operates natively 
+	//     in UTF-16 (or WCHAR) and majority of P4VFS api's require this encoding. Unless otherwise specified, all
+	//     wchar_t* strings in P4VFS are assumed to be WString.
+
 	typedef std::string AString;
 	typedef std::wstring WString;
 	typedef WString String;

--- a/source/P4VFS.Core/Source/FileCore.cpp
+++ b/source/P4VFS.Core/Source/FileCore.cpp
@@ -1108,15 +1108,15 @@ AString StringInfo::ToAnsi(const wchar_t* str)
 		return AString();
 
 	char fixedBuffer[256];
-	int32_t charCount = WideCharToMultiByte(CP_UTF8, 0, str, -1, fixedBuffer, _countof(fixedBuffer), NULL, NULL);
+	int32_t charCount = WideCharToMultiByte(CP_ACP, 0, str, -1, fixedBuffer, _countof(fixedBuffer), NULL, NULL);
 	if (charCount > 0)
 		return AString(fixedBuffer);
 
-	charCount = WideCharToMultiByte(CP_UTF8, 0, str, -1, NULL, 0, NULL, NULL);
+	charCount = WideCharToMultiByte(CP_ACP, 0, str, -1, NULL, 0, NULL, NULL);
 	if (charCount > 0)
 	{
 		std::unique_ptr<char[]> bufferPtr = std::make_unique<char[]>(size_t(charCount));
-		if (bufferPtr.get() && WideCharToMultiByte(CP_UTF8, 0, str, -1, bufferPtr.get(), charCount, NULL, NULL) > 0)
+		if (bufferPtr.get() && WideCharToMultiByte(CP_ACP, 0, str, -1, bufferPtr.get(), charCount, NULL, NULL) > 0)
 			return AString(bufferPtr.get());
 	}
 
@@ -1141,15 +1141,15 @@ WString StringInfo::ToWide(const char* str)
 		return WString();
 
 	wchar_t fixedBuffer[256];
-	int32_t charCount = MultiByteToWideChar(CP_UTF8, 0, str, -1, fixedBuffer, _countof(fixedBuffer));
+	int32_t charCount = MultiByteToWideChar(CP_ACP, 0, str, -1, fixedBuffer, _countof(fixedBuffer));
 	if (charCount > 0)
 		return WString(fixedBuffer);
 
-	charCount = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+	charCount = MultiByteToWideChar(CP_ACP, 0, str, -1, NULL, 0);
 	if (charCount > 0)
 	{
 		std::unique_ptr<wchar_t[]> bufferPtr = std::make_unique<wchar_t[]>(size_t(charCount));
-		if (bufferPtr.get() && MultiByteToWideChar(CP_UTF8, 0, str, -1, bufferPtr.get(), charCount) > 0)
+		if (bufferPtr.get() && MultiByteToWideChar(CP_ACP, 0, str, -1, bufferPtr.get(), charCount) > 0)
 			return WString(bufferPtr.get());
 	}
 

--- a/source/P4VFS.CoreInterop/Include/CoreMarshal.h
+++ b/source/P4VFS.CoreInterop/Include/CoreMarshal.h
@@ -7,15 +7,15 @@ namespace Microsoft {
 namespace P4VFS {
 namespace CoreInterop {
 
-class marshal_as_wchar
+class marshal_as_wstring_c_str
 {
 public:
-	marshal_as_wchar(System::String^ s)
+	marshal_as_wstring_c_str(System::String^ s)
 	{
 		m_hGlobal = System::Runtime::InteropServices::Marshal::StringToHGlobalUni(s);
 	}
 
-	~marshal_as_wchar()
+	~marshal_as_wstring_c_str()
 	{
 		System::Runtime::InteropServices::Marshal::FreeHGlobal(m_hGlobal);
 	}
@@ -29,15 +29,15 @@ private:
 	mutable System::IntPtr m_hGlobal;
 };
 
-class marshal_as_char
+class marshal_as_astring_c_str
 {
 public:
-	marshal_as_char(System::String^ s)
+	marshal_as_astring_c_str(System::String^ s)
 	{
 		m_hGlobal = System::Runtime::InteropServices::Marshal::StringToHGlobalAnsi(s);
 	}
 
-	~marshal_as_char()
+	~marshal_as_astring_c_str()
 	{
 		System::Runtime::InteropServices::Marshal::FreeHGlobal(m_hGlobal);
 	}
@@ -66,7 +66,7 @@ public:
 	}
 
 private:
-	marshal_as_wchar m_String;
+	marshal_as_wstring_c_str m_String;
 };
 
 class marshal_as_astring
@@ -84,7 +84,7 @@ public:
 	}
 
 private:
-	marshal_as_char m_String;
+	marshal_as_astring_c_str m_String;
 };
 
 class marshal_as_user_context
@@ -212,10 +212,24 @@ marshal_as_filetime(System::DateTime^ dateTime)
 
 struct Marshal
 {
-	template <typename StringArrayType>
 	static array<System::String^>^ 
-	FromNative(
-		const StringArrayType& src
+	FromNativeAnsi(
+		const FileCore::AStringArray& src
+		);
+
+	static array<System::String^>^ 
+	FromNativeWide(
+		const FileCore::WStringArray& src
+		);
+
+	static System::String^
+	FromNativeAnsi(
+		const char* src
+		);
+
+	static System::String^
+	FromNativeWide(
+		const wchar_t* src
 		);
 
 	static FileCore::AStringArray

--- a/source/P4VFS.CoreInterop/Include/DepotConstantsInterop.h
+++ b/source/P4VFS.CoreInterop/Include/DepotConstantsInterop.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 #pragma once
 #include "DepotConstants.h"
+#include "CoreMarshal.h"
 
 namespace Microsoft {
 namespace P4VFS {
@@ -10,24 +11,24 @@ namespace CoreInterop {
 public ref class DepotConstants abstract sealed
 {
 public:
-	static const System::String^ P4CHARSET		= gcnew System::String(P4::DepotConstants::P4CHARSET);
-	static const System::String^ P4CLIENT		= gcnew System::String(P4::DepotConstants::P4CLIENT);
-	static const System::String^ P4CONFIG		= gcnew System::String(P4::DepotConstants::P4CONFIG);
-	static const System::String^ P4DIFF			= gcnew System::String(P4::DepotConstants::P4DIFF);
-	static const System::String^ P4EDITOR		= gcnew System::String(P4::DepotConstants::P4EDITOR);
-	static const System::String^ P4HOST			= gcnew System::String(P4::DepotConstants::P4HOST);
-	static const System::String^ P4JOURNAL		= gcnew System::String(P4::DepotConstants::P4JOURNAL);
-	static const System::String^ P4LANGUAGE		= gcnew System::String(P4::DepotConstants::P4LANGUAGE);
-	static const System::String^ P4LOG			= gcnew System::String(P4::DepotConstants::P4LOG);
-	static const System::String^ P4LOGINSSO		= gcnew System::String(P4::DepotConstants::P4LOGINSSO);
-	static const System::String^ P4MERGE		= gcnew System::String(P4::DepotConstants::P4MERGE);
-	static const System::String^ P4PAGER		= gcnew System::String(P4::DepotConstants::P4PAGER);
-	static const System::String^ P4PASSWD		= gcnew System::String(P4::DepotConstants::P4PASSWD);
-	static const System::String^ P4PORT			= gcnew System::String(P4::DepotConstants::P4PORT);
-	static const System::String^ P4ROOT			= gcnew System::String(P4::DepotConstants::P4ROOT);
-	static const System::String^ P4TICKETS		= gcnew System::String(P4::DepotConstants::P4TICKETS);
-	static const System::String^ P4TRUST		= gcnew System::String(P4::DepotConstants::P4TRUST);
-	static const System::String^ P4USER			= gcnew System::String(P4::DepotConstants::P4USER);
+	static initonly System::String^ P4CHARSET		= Marshal::FromNativeAnsi(P4::DepotConstants::P4CHARSET);
+	static initonly System::String^ P4CLIENT		= Marshal::FromNativeAnsi(P4::DepotConstants::P4CLIENT);
+	static initonly System::String^ P4CONFIG		= Marshal::FromNativeAnsi(P4::DepotConstants::P4CONFIG);
+	static initonly System::String^ P4DIFF			= Marshal::FromNativeAnsi(P4::DepotConstants::P4DIFF);
+	static initonly System::String^ P4EDITOR		= Marshal::FromNativeAnsi(P4::DepotConstants::P4EDITOR);
+	static initonly System::String^ P4HOST			= Marshal::FromNativeAnsi(P4::DepotConstants::P4HOST);
+	static initonly System::String^ P4JOURNAL		= Marshal::FromNativeAnsi(P4::DepotConstants::P4JOURNAL);
+	static initonly System::String^ P4LANGUAGE		= Marshal::FromNativeAnsi(P4::DepotConstants::P4LANGUAGE);
+	static initonly System::String^ P4LOG			= Marshal::FromNativeAnsi(P4::DepotConstants::P4LOG);
+	static initonly System::String^ P4LOGINSSO		= Marshal::FromNativeAnsi(P4::DepotConstants::P4LOGINSSO);
+	static initonly System::String^ P4MERGE			= Marshal::FromNativeAnsi(P4::DepotConstants::P4MERGE);
+	static initonly System::String^ P4PAGER			= Marshal::FromNativeAnsi(P4::DepotConstants::P4PAGER);
+	static initonly System::String^ P4PASSWD		= Marshal::FromNativeAnsi(P4::DepotConstants::P4PASSWD);
+	static initonly System::String^ P4PORT			= Marshal::FromNativeAnsi(P4::DepotConstants::P4PORT);
+	static initonly System::String^ P4ROOT			= Marshal::FromNativeAnsi(P4::DepotConstants::P4ROOT);
+	static initonly System::String^ P4TICKETS		= Marshal::FromNativeAnsi(P4::DepotConstants::P4TICKETS);
+	static initonly System::String^ P4TRUST			= Marshal::FromNativeAnsi(P4::DepotConstants::P4TRUST);
+	static initonly System::String^ P4USER			= Marshal::FromNativeAnsi(P4::DepotConstants::P4USER);
 };
 
 }}}

--- a/source/P4VFS.CoreInterop/Include/SettingManagerInterop.h
+++ b/source/P4VFS.CoreInterop/Include/SettingManagerInterop.h
@@ -4,6 +4,7 @@
 #include "SettingManager.h"
 #include "DepotSyncAction.h"
 #include "FileSystem.h"
+#include "CoreMarshal.h"
 
 namespace Microsoft {
 namespace P4VFS {
@@ -151,7 +152,7 @@ namespace SettingTraits
 			const wchar_t* defaultValue
 			) 
 		{ 
-			return n != nullptr ? n->ToString() : gcnew System::String(defaultValue); 
+			return n != nullptr ? n->ToString() : Marshal::FromNativeWide(defaultValue); 
 		}
 
 		static SettingNode^ 

--- a/source/P4VFS.CoreInterop/P4VFS.CoreInterop.vcxproj
+++ b/source/P4VFS.CoreInterop/P4VFS.CoreInterop.vcxproj
@@ -99,7 +99,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;P4VFS_CORE_INTEROP_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
@@ -124,7 +124,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/source/P4VFS.CoreInterop/Source/CoreMarshal.cpp
+++ b/source/P4VFS.CoreInterop/Source/CoreMarshal.cpp
@@ -7,22 +7,52 @@ namespace Microsoft {
 namespace P4VFS {
 namespace CoreInterop {
 
-template <typename StringArrayType>
-array<System::String^>^ 
-Marshal::FromNative(
-	const StringArrayType& src
+template <typename StringArrayType, typename TransformFunction>
+static array<System::String^>^ 
+FromNativeStringArray(
+	const StringArrayType& src,
+	TransformFunction transform
 	)
 {
 	array<System::String^>^ dst = gcnew array<System::String^>(System::Int32(src.size()));
 	for (size_t i = 0; i < src.size(); ++i)
 	{
-		dst[System::Int32(i)] = gcnew System::String(src[i].c_str());
+		dst[System::Int32(i)] = transform(src[i].c_str());
 	}
 	return dst;
 }
 
-template array<System::String^>^ Marshal::FromNative<>(const FileCore::AStringArray& src);
-template array<System::String^>^ Marshal::FromNative<>(const FileCore::WStringArray& src);
+array<System::String^>^ 
+Marshal::FromNativeAnsi(
+	const FileCore::AStringArray& src
+	)
+{
+	return FromNativeStringArray(src, [](const char* s) -> System::String^ { return Marshal::FromNativeAnsi(s); });
+}
+
+array<System::String^>^ 
+Marshal::FromNativeWide(
+	const FileCore::WStringArray& src
+	)
+{
+	return FromNativeStringArray(src, [](const wchar_t* s) -> System::String^ { return Marshal::FromNativeWide(s); });
+}
+
+System::String^
+Marshal::FromNativeAnsi(
+	const char* src
+	)
+{
+	return src ? FromNativeWide(CSTR_ATOW(src)) : nullptr;
+}
+
+System::String^
+Marshal::FromNativeWide(
+	const wchar_t* src
+	)
+{
+	return src ? gcnew System::String(src) : nullptr;
+}
 
 FileCore::AStringArray
 Marshal::ToNativeAnsi(

--- a/source/P4VFS.CoreInterop/Source/DepotClientInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DepotClientInterop.cpp
@@ -21,7 +21,7 @@ P4::DepotClientPromptCallback marshal_as_prompt_callback(System::Func<System::St
 			{
 				try
 				{
-					System::String^ response = callback(gcnew System::String(message.c_str()));
+					System::String^ response = callback(Marshal::FromNativeAnsi(message.c_str()));
 					return marshal_as_astring(response);
 				} 
 				catch (...) 
@@ -232,7 +232,7 @@ DepotClient::SetEnv(
 	)
 {
 	ThrowIfObjectDisposed();
-	return m_Data->m_DepotClient->SetEnv(marshal_as_char(name), marshal_as_char(value));
+	return m_Data->m_DepotClient->SetEnv(marshal_as_astring_c_str(name), marshal_as_astring_c_str(value));
 }
 
 System::String^ 
@@ -241,7 +241,7 @@ DepotClient::GetEnv(
 	)
 {
 	ThrowIfObjectDisposed();
-	return gcnew System::String(m_Data->m_DepotClient->GetEnv(marshal_as_char(name)).c_str());
+	return Marshal::FromNativeAnsi(m_Data->m_DepotClient->GetEnv(marshal_as_astring_c_str(name)).c_str());
 }
 
 System::String^ 
@@ -249,7 +249,7 @@ DepotClient::GetErrorText(
 	)
 {
 	ThrowIfObjectDisposed();
-	return gcnew System::String(m_Data->m_DepotClient->GetErrorText().c_str());
+	return Marshal::FromNativeAnsi(m_Data->m_DepotClient->GetErrorText().c_str());
 }
 
 DepotResult^ 
@@ -305,7 +305,7 @@ DepotInfo::TimeToString(
 	System::Int64 time
 	)
 {
-	return gcnew System::String(P4::DepotInfo::TimeToString(time).c_str());
+	return Marshal::FromNativeAnsi(P4::DepotInfo::TimeToString(time).c_str());
 }
 
 bool 

--- a/source/P4VFS.CoreInterop/Source/DepotConfigInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DepotConfigInterop.cpp
@@ -12,32 +12,32 @@ namespace CoreInterop {
 
 System::String^ DepotConfig::ToString()
 {
-	List<System::String^> args = gcnew List<System::String^>();
+	List<System::String^>^ args = gcnew List<System::String^>();
 	if (System::String::IsNullOrEmpty(Host) == false)
 	{
-		args.Add(System::String::Format("-H \"{0}\"", Host));
+		args->Add(System::String::Format("-H \"{0}\"", Host));
 	}
 	if (System::String::IsNullOrEmpty(Port) == false)
 	{
-		args.Add(System::String::Format("-p \"{0}\"", Port));
+		args->Add(System::String::Format("-p \"{0}\"", Port));
 	}
 	if (System::String::IsNullOrEmpty(Client) == false)
 	{
-		args.Add(System::String::Format("-c \"{0}\"", Client));
+		args->Add(System::String::Format("-c \"{0}\"", Client));
 	}
 	if (System::String::IsNullOrEmpty(User) == false)
 	{
-		args.Add(System::String::Format("-u \"{0}\"", User));
+		args->Add(System::String::Format("-u \"{0}\"", User));
 	}
 	if (System::String::IsNullOrEmpty(Passwd) == false)
 	{
-		args.Add(System::String::Format("-P \"{0}\"", Passwd));
+		args->Add(System::String::Format("-P \"{0}\"", Passwd));
 	}
 	if (System::String::IsNullOrEmpty(Directory) == false)
 	{
-		args.Add(System::String::Format("-d \"{0}\"", Directory));
+		args->Add(System::String::Format("-d \"{0}\"", Directory));
 	}
-	return System::String::Join(" ", args.ToArray());
+	return System::String::Join(" ", args->ToArray());
 }
 
 P4::DepotConfig DepotConfig::ToNative()
@@ -56,13 +56,13 @@ P4::DepotConfig DepotConfig::ToNative()
 DepotConfig^ DepotConfig::FromNative(const P4::DepotConfig& src)
 {
 	DepotConfig^ dst = gcnew DepotConfig();
-	dst->Host = gcnew System::String(src.m_Host.c_str());
-	dst->Port = gcnew System::String(src.m_Port.c_str());
-	dst->Client = gcnew System::String(src.m_Client.c_str());
-	dst->User = gcnew System::String(src.m_User.c_str());
-	dst->Passwd = gcnew System::String(src.m_Passwd.c_str());
-	dst->Ignore = gcnew System::String(src.m_Ignore.c_str());
-	dst->Directory = gcnew System::String(src.m_Directory.c_str());
+	dst->Host = Marshal::FromNativeAnsi(src.m_Host.c_str());
+	dst->Port = Marshal::FromNativeAnsi(src.m_Port.c_str());
+	dst->Client = Marshal::FromNativeAnsi(src.m_Client.c_str());
+	dst->User = Marshal::FromNativeAnsi(src.m_User.c_str());
+	dst->Passwd = Marshal::FromNativeAnsi(src.m_Passwd.c_str());
+	dst->Ignore = Marshal::FromNativeAnsi(src.m_Ignore.c_str());
+	dst->Directory = Marshal::FromNativeAnsi(src.m_Directory.c_str());
 	return dst;
 }
 

--- a/source/P4VFS.CoreInterop/Source/DepotOperationsInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DepotOperationsInterop.cpp
@@ -54,7 +54,7 @@ DepotOperations::GetHeadRevisionChangelist(
 	P4::DepotRevision revision = P4::DepotOperations::GetHeadRevisionChangelist(depotClient->ToNative());
 	if (revision.get() != nullptr)
 	{
-		return gcnew System::String(P4::FDepotRevision::ToString(revision).c_str());
+		return Marshal::FromNativeAnsi(P4::FDepotRevision::ToString(revision).c_str());
 	}
 	return nullptr;
 }
@@ -93,7 +93,7 @@ DepotOperations::CreateFileSpec(
 		P4::FDepotRevision::FromString(marshal_as_astring(revision)),
 		safe_cast<P4::DepotOperations::CreateFileSpecFlags::Enum>(flags));
 
-	return gcnew System::String(result.c_str());
+	return Marshal::FromNativeAnsi(result.c_str());
 }
 
 array<System::String^>^
@@ -110,7 +110,7 @@ DepotOperations::CreateFileSpecs(
 		P4::FDepotRevision::FromString(marshal_as_astring(revision)),
 		safe_cast<P4::DepotOperations::CreateFileSpecFlags::Enum>(flags));
 
-	return Marshal::FromNative(result);
+	return Marshal::FromNativeAnsi(result);
 }
 
 bool
@@ -136,7 +136,7 @@ DepotOperations::GetSymlinkTargetPath(
 		marshal_as_astring(filePath),
 		P4::FDepotRevision::FromString(marshal_as_astring(revision)));
 
-	return gcnew System::String(result.c_str());
+	return Marshal::FromNativeAnsi(result.c_str());
 }
 
 System::String^
@@ -151,7 +151,7 @@ DepotOperations::GetSymlinkTargetDepotFile(
 		marshal_as_astring(filePath),
 		P4::FDepotRevision::FromString(marshal_as_astring(revision)));
 
-	return gcnew System::String(result.c_str());
+	return Marshal::FromNativeAnsi(result.c_str());
 }
 
 System::String^
@@ -162,7 +162,7 @@ DepotOperations::NormalizePath(
 	P4::DepotString result = P4::DepotOperations::NormalizePath(
 		marshal_as_astring(path));
 		
-	return gcnew System::String(result.c_str());
+	return Marshal::FromNativeAnsi(result.c_str());
 }
 
 System::String^ 
@@ -173,7 +173,7 @@ DepotOperations::ResolveDepotServerName(
 	P4::DepotString targetName;
 	if (P4::DepotOperations::ResolveDepotServerName(marshal_as_astring(sourceName), targetName))
 	{
-		return gcnew System::String(targetName.c_str());
+		return Marshal::FromNativeAnsi(targetName.c_str());
 	}
 	return sourceName;
 }
@@ -189,7 +189,7 @@ DepotOperations::GetClientOwnerUserName(
 		marshal_as_astring(clientName),
 		marshal_as_astring(portName));
 
-	return gcnew System::String(userName.c_str());
+	return Marshal::FromNativeAnsi(userName.c_str());
 }
 
 }}}

--- a/source/P4VFS.CoreInterop/Source/DepotResultInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DepotResultInterop.cpp
@@ -26,7 +26,7 @@ DepotResultTag^ DepotResultTag::FromNative(const P4::DepotResultTag& src)
 		dst = gcnew DepotResultTag();
 		for (P4::FDepotResultTag::FieldsType::const_iterator i = src->m_Fields.begin(); i != src->m_Fields.end(); ++i)
 		{
-			dst->m_Fields->Add(gcnew System::String(i->first.c_str()), gcnew System::String(i->second.c_str()));
+			dst->m_Fields->Add(Marshal::FromNativeAnsi(i->first.c_str()), Marshal::FromNativeAnsi(i->second.c_str()));
 		}
 	}
 	return dst;
@@ -91,7 +91,7 @@ DepotResultText^ DepotResultText::FromNative(const P4::DepotResultText& src)
 	{
 		dst = gcnew DepotResultText();
 		dst->Channel = safe_cast<DepotResultChannel>(src->m_Channel);
-		dst->Value = gcnew System::String(src->m_Value.c_str());
+		dst->Value = Marshal::FromNativeAnsi(src->m_Value.c_str());
 		dst->Level = src->m_Level;
 	}
 	return dst;

--- a/source/P4VFS.CoreInterop/Source/DepotSyncActionInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DepotSyncActionInterop.cpp
@@ -48,11 +48,11 @@ DepotSyncActionInfo^ DepotSyncActionInfo::FromNative(const P4::DepotSyncActionIn
 	if (src.get() != nullptr)
 	{
 		dst = gcnew DepotSyncActionInfo();
-		dst->DepotFile = gcnew System::String(src->m_DepotFile.c_str());
-		dst->ClientFile = gcnew System::String(src->m_ClientFile.c_str());
-		dst->Revision = gcnew System::String(P4::FDepotRevision::ToString(src->m_Revision).c_str());
+		dst->DepotFile = Marshal::FromNativeAnsi(src->m_DepotFile.c_str());
+		dst->ClientFile = Marshal::FromNativeAnsi(src->m_ClientFile.c_str());
+		dst->Revision = Marshal::FromNativeAnsi(P4::FDepotRevision::ToString(src->m_Revision).c_str());
 		dst->SyncActionType = safe_cast<DepotSyncActionType>(src->m_SyncActionType);
-		dst->Message = gcnew System::String(src->m_Message.c_str());
+		dst->Message = Marshal::FromNativeAnsi(src->m_Message.c_str());
 	}
 	return dst;
 }

--- a/source/P4VFS.CoreInterop/Source/DriverOperationsInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DriverOperationsInterop.cpp
@@ -15,7 +15,7 @@ DriverOperations::LoadFilter(
 	System::String^ driverName
 	)
 {
-	return P4VFS::DriverOperations::LoadFilter(marshal_as_wchar(driverName));
+	return P4VFS::DriverOperations::LoadFilter(marshal_as_wstring_c_str(driverName));
 }
 
 System::Int32
@@ -23,7 +23,7 @@ DriverOperations::UnloadFilter(
 	System::String^ driverName
 	)
 {
-	return P4VFS::DriverOperations::UnloadFilter(marshal_as_wchar(driverName));
+	return P4VFS::DriverOperations::UnloadFilter(marshal_as_wstring_c_str(driverName));
 }
 
 System::Boolean
@@ -31,7 +31,7 @@ DriverOperations::IsFilterLoaded(
 	System::String^ driverName
 	)
 {
-	return P4VFS::DriverOperations::IsFilterLoaded(marshal_as_wchar(driverName));
+	return P4VFS::DriverOperations::IsFilterLoaded(marshal_as_wstring_c_str(driverName));
 }
 
 System::Int32
@@ -45,7 +45,7 @@ DriverOperations::GetLoadedFilters(
 	HRESULT hr = P4VFS::DriverOperations::GetLoadedFilters(srcNames);
 	if (SUCCEEDED(hr))
 	{
-		driverNames = Marshal::FromNative(srcNames);
+		driverNames = Marshal::FromNativeWide(srcNames);
 	}
 	return hr;
 }

--- a/source/P4VFS.CoreInterop/Source/Pch.h
+++ b/source/P4VFS.CoreInterop/Source/Pch.h
@@ -4,6 +4,7 @@
 
 #pragma warning(disable : 4127) // conditional expression is constant
 #pragma warning(disable : 4100) // unreferenced formal parameter
+#pragma warning(disable : 4239) // nonstandard extension used : 'token' : conversion from 'type' to 'type'
 #include <SDKDDKVer.h>
 
 #include <tchar.h>

--- a/source/P4VFS.CoreInterop/Source/ServiceOperationsInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/ServiceOperationsInterop.cpp
@@ -19,10 +19,10 @@ ServiceOperations::InstallLocalService(
 	)
 {
 	return P4VFS::ServiceOperations::InstallLocalService(
-		marshal_as_wchar(pathToServiceBinary), 
-		marshal_as_wchar(serviceName), 
-		marshal_as_wchar(friendlyServiceName),
-		marshal_as_wchar(serviceDescription)
+		marshal_as_wstring_c_str(pathToServiceBinary), 
+		marshal_as_wstring_c_str(serviceName), 
+		marshal_as_wstring_c_str(friendlyServiceName),
+		marshal_as_wstring_c_str(serviceDescription)
 		);
 }
 
@@ -33,7 +33,7 @@ ServiceOperations::UninstallLocalService(
 	)
 {
 	return P4VFS::ServiceOperations::UninstallLocalService(
-		marshal_as_wchar(serviceName),
+		marshal_as_wstring_c_str(serviceName),
 		safe_cast<P4VFS::ServiceOperations::UninstallFlags::Enum>(flags)
 		);
 }
@@ -44,7 +44,7 @@ ServiceOperations::StartLocalService(
 	)
 {
 	return P4VFS::ServiceOperations::StartLocalService(
-		marshal_as_wchar(serviceName)
+		marshal_as_wstring_c_str(serviceName)
 		);
 }
 
@@ -54,7 +54,7 @@ ServiceOperations::StopLocalService(
 	)
 {
 	return P4VFS::ServiceOperations::StopLocalService(
-		marshal_as_wchar(serviceName)
+		marshal_as_wstring_c_str(serviceName)
 		);
 }
 
@@ -64,7 +64,7 @@ ServiceOperations::GetLocalServiceState(
 	)
 {
 	return P4VFS::ServiceOperations::GetLocalServiceState(
-		marshal_as_wchar(serviceName)
+		marshal_as_wstring_c_str(serviceName)
 		);
 }
 

--- a/source/P4VFS.CoreInterop/Source/SettingManagerInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/SettingManagerInterop.cpp
@@ -138,7 +138,7 @@ SettingNode::FromNative(
 	)
 {
 	SettingNode^ node = gcnew SettingNode();
-	node->m_Data = gcnew System::String(srcNode.GetString().c_str());
+	node->m_Data = Marshal::FromNativeWide(srcNode.GetString().c_str());
 	node->m_Nodes = gcnew array<SettingNode^>(int32_t(srcNode.Nodes().size()));
 	for (uint32_t i = 0; i < srcNode.Nodes().size(); ++i)
 	{
@@ -192,7 +192,7 @@ SettingManager::GetProperties(
 	SettingNodeMap^ nodeMap = gcnew SettingNodeMap();
 	for (FileCore::SettingManager::PropertyMap::const_iterator propertyIt = propertyMap.begin(); propertyIt != propertyMap.end(); ++propertyIt)
 	{
-		nodeMap[gcnew System::String(propertyIt->first.c_str())] = SettingNode::FromNative(propertyIt->second);
+		nodeMap[Marshal::FromNativeWide(propertyIt->first.c_str())] = SettingNode::FromNative(propertyIt->second);
 	}
 	return nodeMap;
 }
@@ -209,9 +209,12 @@ SettingManager::SetProperties(
 	if (nodeMap->Count > 0)
 	{
 		FileCore::SettingManager::PropertyMap propertyMap;
-		for each (System::Collections::Generic::KeyValuePair<System::String^, SettingNode^> keyValue in nodeMap)
+		for each (System::Collections::Generic::KeyValuePair<System::String^, SettingNode^>^ keyValue in nodeMap)
 		{
-			propertyMap[marshal_as_wstring(keyValue.Key)] = keyValue.Value ? keyValue.Value->ToNative() : FileCore::SettingNode();
+			if (keyValue != nullptr)
+			{
+				propertyMap[marshal_as_wstring(keyValue->Key)] = keyValue->Value ? keyValue->Value->ToNative() : FileCore::SettingNode();
+			}
 		}
 		FileCore::SettingManager::StaticInstance().SetProperties(propertyMap);
 	}

--- a/source/P4VFS.CoreInterop/Tests/TestFactoryInterop.cpp
+++ b/source/P4VFS.CoreInterop/Tests/TestFactoryInterop.cpp
@@ -33,7 +33,7 @@ TestFactoryInterop::Run(
 
 		factoryContext.m_ReconcilePreviewAny = [&gccontext](const FileCore::String& s) -> bool 
 		{ 
-			return gccontext->m_ReconcilePreviewAny(gcnew System::String(s.c_str())); 
+			return gccontext->m_ReconcilePreviewAny(Marshal::FromNativeWide(s.c_str())); 
 		};
 
 		factoryContext.m_WorkspaceReset = [&gccontext]() -> void 
@@ -43,7 +43,7 @@ TestFactoryInterop::Run(
 
 		factoryContext.m_IsPlaceholderFile = [&gccontext](const FileCore::String& s) -> bool 
 		{ 
-			return gccontext->m_IsPlaceholderFile(gcnew System::String(s.c_str())); 
+			return gccontext->m_IsPlaceholderFile(Marshal::FromNativeWide(s.c_str())); 
 		};
 
 		factoryContext.m_ServiceLastRequestTime = [&gccontext]() -> FILETIME 
@@ -64,7 +64,7 @@ TestFactoryInterop::Run(
 	}
 	catch (std::exception e)
 	{
-		throw gcnew System::Exception(gcnew System::String(e.what()));
+		throw gcnew System::Exception(Marshal::FromNativeAnsi(e.what()));
 	}
 	catch (...)
 	{

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -4,7 +4,7 @@
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					26			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					0			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v

--- a/source/P4VFS.UnitTest/Resource/ServerRecipe.xml
+++ b/source/P4VFS.UnitTest/Resource/ServerRecipe.xml
@@ -1,4 +1,4 @@
-ï»¿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="Windows-1252" ?>
 <!--
   ============================================================================================
   This file is authored manually. It contains the change specifications to describe filespecs
@@ -81,4 +81,13 @@
     <file path="//depot/tools/dev/external/packages/thirdparty/microsoft/Windows Kits/10/References/10.0.17134.0/Windows.System.Profile.SystemManufacturers.SystemManufacturersContract/3.0.0.0/zh-hans/Windows.System.Profile.SystemManufacturers.SystemManufacturersContract.xml" size="4167" type="text" rev="1" />
     <file path="//depot/tools/dev/external/packages/thirdparty/microsoft/Windows Kits/10/References/10.0.17134.0/Windows.System.Profile.SystemManufacturers.SystemManufacturersContract/3.0.0.0/zh-hant/Windows.System.Profile.SystemManufacturers.SystemManufacturersContract.xml" size="4165" type="text" rev="1" />
   </change>
+  <change fstat="//depot/tools/dev/documentation/...@7102178">
+    <file path="//depot/tools/dev/documentation/français/LaCédille.txt" size="175" type="text" rev="1" />
+    <file path="//depot/tools/dev/documentation/français/Médecin.txt" size="135" type="text" rev="1" />
+    <file path="//depot/tools/dev/documentation/français/deuxième.txt" size="80" type="text" rev="1" />
+    <file path="//depot/tools/dev/documentation/français/forêt.txt" size="20" type="text" rev="1" />
+    <file path="//depot/tools/dev/documentation/français/coïncidence.txt" size="35" type="text" rev="1" />
+    <file path="//depot/tools/dev/documentation/anglaise/microsoft©.txt" size="34" type="text" rev="1" />
+    <file path="//depot/tools/dev/documentation/anglaise/xbox—one.txt" size="33" type="text" rev="1" />
+  </change>  
 </server>

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -53,6 +53,21 @@ namespace Microsoft.P4VFS.UnitTest
 					}
 				}
 
+				int argIndex = 0;
+				for (; argIndex < args.Length; ++argIndex)
+				{
+					if (String.Compare(args[argIndex], "-r") == 0)
+					{
+						IsTestRemote = true;
+					}
+					else
+					{
+						break;
+					}
+				}
+
+				args = args.Skip(argIndex).ToArray();
+
 				Assembly unitTestAssembly = Assembly.GetExecutingAssembly();
 				List<TestMethodInfo> testMethods = new List<TestMethodInfo>();
 				foreach (Type unitTestClassType in unitTestAssembly.GetTypes().Where(t => t.IsClass && t.GetCustomAttribute<TestClassAttribute>(true) != null))
@@ -336,6 +351,12 @@ namespace Microsoft.P4VFS.UnitTest
 			return null;
 		}
 
+		public static bool IsTestRemote
+		{
+			get;
+			private set;
+		}
+
 		private static string _P4dExe;
 		public static string P4dExe
 		{
@@ -345,7 +366,7 @@ namespace Microsoft.P4VFS.UnitTest
 		private static string _P4Exe;
 		public static string P4Exe
 		{
-			get { return GetCachedFilePath(ref _P4Exe, () => String.Format("{0}\\bin\\p4.exe", GetExternalModuleFolder("P4API"))); }
+			get { return IsTestRemote ? "p4.exe" : GetCachedFilePath(ref _P4Exe, () => String.Format("{0}\\bin\\p4.exe", GetExternalModuleFolder("P4API"))); }
 		}
 
 		private static string _P4vfsExe;
@@ -401,13 +422,13 @@ namespace Microsoft.P4VFS.UnitTest
 			return Path.GetFullPath(String.Format(@"{0}\external", GetRepositoryRootFolder()));
 		}
 
-		public static string GetExternalModuleFolder(string moduleName)
+		public static string GetExternalModuleFolder(string moduleName, bool required = false)
 		{
 			string folderPath = Directory.GetDirectories(String.Format(@"{0}\{1}", GetExternalRootFolder(), moduleName))
 				.Where(path => Regex.IsMatch(Path.GetFileName(path), @"^\d+\.\d+"))
 				.OrderBy(path => Path.GetFileName(path))
 				.FirstOrDefault();
-			Assert(Directory.Exists(folderPath));
+			Assert(Directory.Exists(folderPath) || required == false);
 			return folderPath;
 		}
 

--- a/source/P4VFS.UnitTest/Source/UnitTestRemote.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestRemote.cs
@@ -59,7 +59,7 @@ namespace Microsoft.P4VFS.UnitTest
 			};
 
 			Assert(remoteTests.Count > 0);
-			string remoteTestsArgs = String.Join(" ", remoteTests.ToArray());
+			string remoteTestsArgs = String.Join(" ", new[]{"-r"}.Concat(remoteTests.Select(t => t.ToString())));
 			AssertLambda(() => CreateRemoteFirewallSettings(remoteConfig));
 			Assert(RemoteExecuteWait(String.Format("\"{0}\" {1} login", InstalledP4vfsExe, remoteConfig)) == 0);
 			Assert(RemoteExecuteWait(String.Format("\"{0}\" {1} test {2}", InstalledP4vfsExe, remoteConfig, remoteTestsArgs), admin:true) == 0);

--- a/source/P4VFS.UnitTest/Source/UnitTestServer.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestServer.cs
@@ -819,6 +819,9 @@ namespace Microsoft.P4VFS.UnitTest
 				if (String.IsNullOrEmpty(fstat) == false)
 				{
 					Assert(historyFStatElements.TryGetValue(fstat, out XmlElement historyChangeElement), "Empty changelist in recipe document");
+					Assert(historyChangeElement != null, "History change already used");
+					historyFStatElements[fstat] = null;
+
 					Assert(historyChangeElement.ChildNodes.OfType<XmlElement>().Any(), "Empty changelist in history document");
 					foreach (XmlElement historyElement in historyChangeElement.ChildNodes.OfType<XmlElement>())
 					{
@@ -826,6 +829,8 @@ namespace Microsoft.P4VFS.UnitTest
 					}
 				}
 			}
+
+			Assert(historyFStatElements.Values.All(historyChangeElement => historyChangeElement == null), "Not all history changes used");
 		}
   	}
 }


### PR DESCRIPTION
Fixing #15 

Version [1.26.1.0]
* Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.
  Additional unit test for handling file paths containing common french accent marks.
* Fixing execution of remote unit tests requiring an installed p4.exe instead of using
  the included P4VFS external binaries