### PR TITLE
1.27.0.0 Release

### DIFF
--- a/deploy/pipelines/templates/p4vfs-cd.yml
+++ b/deploy/pipelines/templates/p4vfs-cd.yml
@@ -31,8 +31,8 @@ jobs:
           displayName: 'P4VFS Publish'
           inputs:
             solution: '$(Pipeline.Workspace)/drop/source/P4VFS.Setup/P4VFS.Setup.targets'
-            msbuildVersion: 17.0
-            msbuildArchitecture: x64
+            msbuildVersion: '17.0'
+            msbuildArchitecture: 'x64'
             configuration: ${{parameters.configuration}}
             msbuildArguments: '/Target:P4VFSDeploySetup ${{parameters.additionalBuildArguments}}'
 

--- a/deploy/pipelines/templates/p4vfs-ci.yml
+++ b/deploy/pipelines/templates/p4vfs-ci.yml
@@ -51,19 +51,28 @@ jobs:
   - task: PublishSymbols@2
     displayName: 'Publish Symbols'
     inputs:
-      SearchPattern: '**/builds/**/*.pdb'
+      SearchPattern: 'intermediate/builds/**/p4vfs*.pdb'
       SymbolServerType: 'TeamServices'
+      IndexSources: false
 
   - task: CopyFiles@2
     displayName: 'Stage Artifacts'
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)'
       contents: |
-        intermediate/*/P4VFS.Setup/*/*.exe
         intermediate/*/P4VFS.Setup/**/Resource/*.nuspec
         source/**/+(*.props|*.targets)
         nuget.config
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: MSBuild@1
+    displayName: 'Stage Setup'
+    inputs:
+      solution: 'source/P4VFS.Setup/P4VFS.Setup.targets'
+      msbuildVersion: '17.0'
+      msbuildArchitecture: 'x64'
+      configuration: ${{parameters.configuration}}
+      msbuildArguments: '/Target:P4VFSDeploySetup /Property:P4VFSPublishDeployDir=$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifacts'

--- a/deploy/pipelines/templates/p4vfs-ci.yml
+++ b/deploy/pipelines/templates/p4vfs-ci.yml
@@ -60,7 +60,8 @@ jobs:
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)'
       contents: |
-        intermediate/*/P4VFS.Setup/**/Resource/*.nuspec
+        intermediate/*/P4VFS.Setup/*/Resource/*.nuspec
+		intermediate/*/P4VFS.Setup/*/*.exe
         source/**/+(*.props|*.targets)
         nuget.config
       TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/deploy/pipelines/templates/p4vfs-ci.yml
+++ b/deploy/pipelines/templates/p4vfs-ci.yml
@@ -61,7 +61,7 @@ jobs:
       sourceFolder: '$(Build.SourcesDirectory)'
       contents: |
         intermediate/*/P4VFS.Setup/*/Resource/*.nuspec
-		intermediate/*/P4VFS.Setup/*/*.exe
+        intermediate/*/P4VFS.Setup/*/*.exe
         source/**/+(*.props|*.targets)
         nuget.config
       TargetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/external/OpenSSL/OpenSSL.Module.cs
+++ b/external/OpenSSL/OpenSSL.Module.cs
@@ -12,7 +12,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class OpensslModule : Module
 	{
-		private const string OPENSSL_VERSION = "1.1.1t";
+		private const string OPENSSL_VERSION = "1.1.1v";
 		private const string PERL_PACKAGE_NAME = "StrawberryPerl";
 		private const string PERL_VERSION = "5.28.0.1";
 

--- a/external/P4API/P4API.Module.cs
+++ b/external/P4API/P4API.Module.cs
@@ -12,7 +12,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class P4apiModule : Module
 	{
-		private const string P4API_VERSION = "r23.1";
+		private const string P4API_VERSION = "r23.2";
 		private const string P4API_VISUAL_STUDIO_EDITION = "2022";
 
 		public override string Name

--- a/external/P4API/P4API.Module.cs
+++ b/external/P4API/P4API.Module.cs
@@ -12,8 +12,8 @@ namespace Microsoft.P4VFS.External
 {
 	public class P4apiModule : Module
 	{
-		private const string P4API_VERSION = "r21.2";
-		private const string P4API_VISUAL_STUDIO_EDITION = "2019"; // TODO: Remove when P4API libs are available for 2022  
+		private const string P4API_VERSION = "r23.1";
+		private const string P4API_VISUAL_STUDIO_EDITION = "2022";
 
 		public override string Name
 		{

--- a/external/P4VFS/P4VFS.Module.cs
+++ b/external/P4VFS/P4VFS.Module.cs
@@ -11,7 +11,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class P4vfsModule : Module
 	{
-		private const string P4VFS_SIGNED_VERSION = "1.26.0.0";
+		private const string P4VFS_SIGNED_VERSION = "1.27.0.0";
 		private const string P4VFS_SIGNED_ARTIFACTS_URL = "https://github.com/microsoft/p4vfs/releases/download";
 
 		public override string Name

--- a/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
+++ b/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
@@ -90,22 +90,22 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core">
-      <Version>1.33.0</Version>
+      <Version>1.36.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
-      <Version>1.9.0</Version>
+      <Version>1.10.3</Version>
     </PackageReference>
     <PackageReference Include="Azure.Security.KeyVault.Secrets">
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Storage.Blobs">
-      <Version>12.16.0</Version>
+      <Version>12.19.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.6.1</Version>
+      <Version>6.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
+++ b/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
@@ -93,19 +93,19 @@
       <Version>1.36.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
-      <Version>1.10.3</Version>
+      <Version>1.10.4</Version>
     </PackageReference>
     <PackageReference Include="Azure.Security.KeyVault.Secrets">
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Storage.Blobs">
-      <Version>12.19.0</Version>
+      <Version>12.19.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.7.0</Version>
+      <Version>6.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/P4VFS.Console/P4VFS.Console.csproj
+++ b/source/P4VFS.Console/P4VFS.Console.csproj
@@ -149,7 +149,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,7 +1,9 @@
 Microsoft P4VFS Release Notes
 
 Version [1.27.0.0]
-* Updating to P4API 2023.1 and OpenSSL 1.1.1v. UnitTest now uses p4d.exe/p4.exe 2023.1
+* New sync -c option to force the placeholder file size to be the expected workspace 
+  file size, instead of server file size. This requires server 2023.1 or later.
+* Updating to P4API 2023.2 and OpenSSL 1.1.1v. UnitTest now uses p4d.exe/p4.exe 2023.1
 * P4VFS.External checksum verification fix to handle unexpected whitespace around SHA256
 * Driver IRP_MJ_CREATE PostCreate callback fix for properly ignoring reparse on non-P4VFS 
   files with FileTag matching our P4VFS_REPARSE_TAG.
@@ -11,6 +13,7 @@ Version [1.27.0.0]
 * Additional tests for elevated access requirements for internal p4vfsflt control port 
   operations
 * Fixing stdout display of native unit test assertions and other inner assertions
+* Fixing bug where "Text" would appear at the top of the Setup details output.
 
 Version [1.26.1.0]
 * Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,11 @@
 Microsoft P4VFS Release Notes
 
+Version [1.27.0.0]
+* Updating to P4API 2023.1 and OpenSSL 1.1.1v. UnitTest now uses p4d.exe/p4.exe 2023.1
+* P4VFS.External checksum verification fix to handle unexpected whitespace around SHA256
+* Driver IRP_MJ_CREATE PostCreate callback fix for properly ignoring reparse on non-P4VFS 
+  files with FileTag matching our P4VFS_REPARSE_TAG.
+
 Version [1.26.1.0]
 * Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.
   Additional unit test for handling file paths containing common french accent marks.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -8,6 +8,8 @@ Version [1.27.0.0]
 * Driver now requires process to be elevated in order to set control paramters (p4vfs ctrl)
 * Addition of DepotClient accessor for server protocol level used for testing for server 
   features and unicode behavior
+* Additional tests for elevated access requirements for internal p4vfsflt control port 
+  operations
 
 Version [1.26.1.0]
 * Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -5,6 +5,9 @@ Version [1.27.0.0]
 * P4VFS.External checksum verification fix to handle unexpected whitespace around SHA256
 * Driver IRP_MJ_CREATE PostCreate callback fix for properly ignoring reparse on non-P4VFS 
   files with FileTag matching our P4VFS_REPARSE_TAG.
+* Driver now requires process to be elevated in order to set control paramters (p4vfs ctrl)
+* Addition of DepotClient accessor for server protocol level used for testing for server 
+  features and unicode behavior
 
 Version [1.26.1.0]
 * Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -10,6 +10,7 @@ Version [1.27.0.0]
   features and unicode behavior
 * Additional tests for elevated access requirements for internal p4vfsflt control port 
   operations
+* Fixing stdout display of native unit test assertions and other inner assertions
 
 Version [1.26.1.0]
 * Fixing support for file paths including non-ASCII single-byte (CP-1252) encoded characters.

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -109,6 +109,8 @@ Available commands:
               Atomic : Performs a guaranteed safe-to-terminate sync to be performed where
                        a Flush is sent to the server per file synced. This operation
                        is cancellation safe.
+    -c        Force the placeholder file size to be the expected workspace file size,
+              instead of server file size. This requires server 2023.1 or later.
 "},
 
 {"info", @"

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -474,6 +474,10 @@ Available commands:
 					}
 					explicitFlush = flushType;
 				}
+				else if (String.Compare(args[argIndex], "-c") == 0)
+				{
+					syncFlags |= DepotSyncFlags.Writeable;
+				}
 				else
 				{
 					break;

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -405,7 +405,7 @@ Available commands:
 			SyncProtocol syncProtocol = SyncProtocol.Service | SyncProtocol.Local;
 			string syncResident = SettingManager.SyncResidentPattern?.Trim();
 			
-			DepotSyncType syncType = SettingManager.SyncDefaultQuiet ? DepotSyncType.Quiet : DepotSyncType.Normal;
+			DepotSyncFlags syncFlags = SettingManager.SyncDefaultQuiet ? DepotSyncFlags.Quiet : DepotSyncFlags.Normal;
 			DepotFlushType flushType = SettingManagerExtensions.DefaultFlushType;
 			DepotFlushType? explicitFlush = null;
 
@@ -415,36 +415,36 @@ Available commands:
 				if (String.Compare(args[argIndex], "-v") == 0)
 				{
 					syncMethod = DepotSyncMethod.Virtual;
-					syncType &= ~DepotSyncType.IgnoreOutput;
+					syncFlags &= ~DepotSyncFlags.IgnoreOutput;
 				}
 				else if (String.Compare(args[argIndex], "-r") == 0)
 				{
 					syncMethod = DepotSyncMethod.Regular;
-					syncType |= DepotSyncType.IgnoreOutput;
+					syncFlags |= DepotSyncFlags.IgnoreOutput;
 				}
 				else if (String.Compare(args[argIndex], "-f") == 0)
 				{
-					syncType |= DepotSyncType.Force;
+					syncFlags |= DepotSyncFlags.Force;
 				}
 				else if (String.Compare(args[argIndex], "-q") == 0)
 				{
-					syncType |= DepotSyncType.Quiet;
+					syncFlags |= DepotSyncFlags.Quiet;
 				}
 				else if (String.Compare(args[argIndex], "-l") == 0)
 				{
-					syncType &= ~DepotSyncType.Quiet;
+					syncFlags &= ~DepotSyncFlags.Quiet;
 				}
 				else if (String.Compare(args[argIndex], "-n") == 0)
 				{
-					syncType |= DepotSyncType.Preview;
+					syncFlags |= DepotSyncFlags.Preview;
 				}
 				else if (String.Compare(args[argIndex], "-k") == 0)
 				{
-					syncType |= DepotSyncType.Flush;
+					syncFlags |= DepotSyncFlags.Flush;
 				}
 				else if (String.Compare(args[argIndex], "-w") == 0)
 				{
-					syncType |= DepotSyncType.Writeable;
+					syncFlags |= DepotSyncFlags.Writeable;
 				}
 				else if (String.Compare(args[argIndex], "-t") == 0)
 				{
@@ -478,7 +478,7 @@ Available commands:
 				}
 			}
 
-			if (syncType.HasFlag(DepotSyncType.Quiet) && explicitFlush == null)
+			if (syncFlags.HasFlag(DepotSyncFlags.Quiet) && explicitFlush == null)
 			{
 				flushType = DepotFlushType.Atomic;
 			}
@@ -488,13 +488,13 @@ Available commands:
 
 			DepotSyncOptions syncOptions = new DepotSyncOptions();
 			syncOptions.Files = files.ToArray();
-			syncOptions.SyncType = syncType;
+			syncOptions.SyncFlags = syncFlags;
 			syncOptions.SyncMethod = syncMethod;
 			syncOptions.SyncResident = syncResident;
 			syncOptions.FlushType = flushType;
 			syncOptions.Context = new CoreInterop.UserContext { ProcessId = Process.GetCurrentProcess().Id };
 
-			if (syncType.HasFlag(DepotSyncType.Quiet))
+			if (syncFlags.HasFlag(DepotSyncFlags.Quiet))
 			{
 				SettingManagerExtensions.Verbosity = LogChannel.Warning;
 			}
@@ -701,7 +701,7 @@ Available commands:
 		{
 			SyncProtocol syncProtocol = SyncProtocol.Service | SyncProtocol.Local;
 			DepotSyncMethod syncMethod = DepotSyncMethod.Regular;
-			DepotSyncType syncType = SettingManager.SyncDefaultQuiet ? DepotSyncType.Quiet : DepotSyncType.Normal;
+			DepotSyncFlags syncFlags = SettingManager.SyncDefaultQuiet ? DepotSyncFlags.Quiet : DepotSyncFlags.Normal;
 			string syncResident = null;
 
 			int argIndex = 0;
@@ -717,7 +717,7 @@ Available commands:
 				}
 				else if (String.Compare(args[argIndex], "-n") == 0)
 				{
-					syncType |= DepotSyncType.Preview;
+					syncFlags |= DepotSyncFlags.Preview;
 				}
 				else if (String.Compare(args[argIndex], "-t") == 0)
 				{
@@ -737,11 +737,11 @@ Available commands:
 				}
 				else if (String.Compare(args[argIndex], "-q") == 0)
 				{
-					syncType |= DepotSyncType.Quiet;
+					syncFlags |= DepotSyncFlags.Quiet;
 				}
 				else if (String.Compare(args[argIndex], "-l") == 0)
 				{
-					syncType &= ~DepotSyncType.Quiet;
+					syncFlags &= ~DepotSyncFlags.Quiet;
 				}
 				else
 				{
@@ -752,7 +752,7 @@ Available commands:
 			List<string> fileArguments = new List<string>(args.Skip(argIndex));
 			fileArguments.AddRange(ReadInputFileArgs());
 
-			if (syncType.HasFlag(DepotSyncType.Quiet))
+			if (syncFlags.HasFlag(DepotSyncFlags.Quiet))
 			{
 				SettingManagerExtensions.Verbosity = LogChannel.Warning;
 			}
@@ -769,7 +769,7 @@ Available commands:
 				{
 					DepotSyncOptions syncOptions = new DepotSyncOptions();
 					syncOptions.Files = fileArguments.ToArray();
-					syncOptions.SyncType = DepotSyncType.Force | syncType;
+					syncOptions.SyncFlags = DepotSyncFlags.Force | syncFlags;
 					syncOptions.SyncMethod = DepotSyncMethod.Virtual;
 					syncOptions.SyncResident = String.IsNullOrEmpty(syncResident) ? null : String.Format("^(?!.*({0})).*$", syncResident);
 					syncOptions.Revision = new DepotRevisionHave().ToString();
@@ -794,7 +794,7 @@ Available commands:
 				{
 					DepotSyncOptions syncOptions = new DepotSyncOptions();
 					syncOptions.Files = fileArguments.ToArray();
-					syncOptions.SyncType = syncType;
+					syncOptions.SyncFlags = syncFlags;
 					syncOptions.SyncResident = syncResident;
 
 					VirtualFileSystemLog.Verbose("Hydrating files ...");

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -882,7 +882,7 @@ Available commands:
 			ushort minor = 0;
 			ushort build = 0;
 			ushort revision = 0;
-			result &= PredicateLog(() => CoreInterop.NativeMethods.GetDriverVersion(ref major, ref minor, ref build, ref revision), "GetDriverVersion");
+			result &= PredicateLog(() => CoreInterop.NativeMethods.GetDriverVersion(out major, out minor, out build, out revision), "GetDriverVersion");
 			result &= PredicateLog(() => CoreInterop.NativeConstants.VersionMajor == major, String.Format("Driver major version {0} expected {1}", major, CoreInterop.NativeConstants.VersionMajor));
 			return result;
 		}
@@ -1115,8 +1115,7 @@ Available commands:
 				{
 					if (String.Compare(args[argIndex], "-dc") == 0)
 					{
-						bool connected = false;
-						if (CoreInterop.NativeMethods.GetDriverIsConnected(ref connected) == false)
+						if (CoreInterop.NativeMethods.GetDriverIsConnected(out bool connected) == false)
 						{
 							VirtualFileSystemLog.Error("Failed to GetDriverIsConnected");
 							return false;

--- a/source/P4VFS.Core/Include/DepotClient.h
+++ b/source/P4VFS.Core/Include/DepotClient.h
@@ -42,9 +42,11 @@ namespace P4 {
 		P4VFS_CORE_API DepotResultInfo Info();
 
 		P4VFS_CORE_API void Reset();
-		P4VFS_CORE_API bool HasError();
-		P4VFS_CORE_API DepotString GetErrorText();
-		P4VFS_CORE_API int32_t GetServerProtocol();
+		P4VFS_CORE_API bool HasError() const;
+		P4VFS_CORE_API DepotString GetErrorText() const;
+		P4VFS_CORE_API int32_t GetProtocol(const char* tag, int32_t defaultValue = 0) const;
+		P4VFS_CORE_API int32_t GetServerApiLevel() const;
+		P4VFS_CORE_API bool IsServerUnicode() const;
 
 		P4VFS_CORE_API DepotString GetProgramName() const;
 		P4VFS_CORE_API DepotString GetTicketsFilePath() const;
@@ -138,8 +140,8 @@ namespace P4 {
 	struct DepotTunable
 	{
 		P4VFS_CORE_API static int32_t Get(const DepotString& name, int32_t defaultValue = -1);
-		P4VFS_CORE_API static void	Set(const DepotString& name, int32_t value);
-		P4VFS_CORE_API static void	Unset(const DepotString& name);
+		P4VFS_CORE_API static void Set(const DepotString& name, int32_t value);
+		P4VFS_CORE_API static void Unset(const DepotString& name);
 		P4VFS_CORE_API static bool IsSet(const DepotString& name);
 		P4VFS_CORE_API static bool IsKnown(const DepotString& name);
 	};

--- a/source/P4VFS.Core/Include/DepotClient.h
+++ b/source/P4VFS.Core/Include/DepotClient.h
@@ -44,6 +44,7 @@ namespace P4 {
 		P4VFS_CORE_API void Reset();
 		P4VFS_CORE_API bool HasError();
 		P4VFS_CORE_API DepotString GetErrorText();
+		P4VFS_CORE_API int32_t GetServerProtocol();
 
 		P4VFS_CORE_API DepotString GetProgramName() const;
 		P4VFS_CORE_API DepotString GetTicketsFilePath() const;

--- a/source/P4VFS.Core/Include/DepotConstants.h
+++ b/source/P4VFS.Core/Include/DepotConstants.h
@@ -35,6 +35,7 @@ namespace P4 {
 
 	// https://www.perforce.com/manuals/p4sag/Content/P4SAG/protocol-levels.html
 	#define DEPOT_PROTOCOL_LEVELS(_N) \
+		_N( 2023_2, 57, 95 ) \
 		_N( 2023_1, 56, 94 ) \
 		_N( 2022_2, 55, 93 ) \
 		_N( 2022_1, 54, 92 ) \

--- a/source/P4VFS.Core/Include/DepotConstants.h
+++ b/source/P4VFS.Core/Include/DepotConstants.h
@@ -33,6 +33,64 @@ namespace P4 {
 		static constexpr char* USERPROFILE	= "USERPROFILE";
 	};
 
+	// https://www.perforce.com/manuals/p4sag/Content/P4SAG/protocol-levels.html
+	#define DEPOT_PROTOCOL_LEVELS(_N) \
+		_N( 2023_1, 56, 94 ) \
+		_N( 2022_2, 55, 93 ) \
+		_N( 2022_1, 54, 92 ) \
+		_N( 2021_2, 53, 91 ) \
+		_N( 2021_1, 52, 90 ) \
+		_N( 2020_2, 51, 89 ) \
+		_N( 2020_1, 50, 88 ) \
+		_N( 2019_2, 49, 87 ) \
+		_N( 2019_1, 47, 86 ) \
+		_N( 2018_2, 46, 85 ) \
+		_N( 2018_1, 45, 84 ) \
+		_N( 2017_2, 44, 83 ) \
+		_N( 2017_1, 43, 82 ) \
+		_N( 2016_2, 42, 81 ) \
+		_N( 2016_1, 41, 80 ) \
+		_N( 2015_2, 40, 79 ) \
+		_N( 2015_1, 39, 78 ) \
+		_N( 2014_2, 38, 77 ) \
+		_N( 2014_1, 37, 76 ) \
+		_N( 2013_3, 36, 75 ) \
+		_N( 2013_2, 35, 74 ) \
+		_N( 2013_1, 34, 73 ) \
+		_N( 2012_2, 33, 72 ) \
+		_N( 2012_1, 32, 71 ) \
+		_N( 2011_1, 31, 70 ) \
+		_N( 2010_2, 30, 68 ) \
+		_N( 2010_1, 29, 67 ) \
+		_N( 2009_2, 28, 66 ) \
+		_N( 2009_1, 27, 65 ) \
+		_N( 2008_2, 26, 64 ) \
+		_N( 2008_1, 25, 63 ) \
+		_N( 2007_3, 24, 62 ) \
+		_N( 2007_2, 23, 61 ) \
+		_N( 2006_2, 22, 60 ) \
+		_N( 2006_1, 21, 59 ) \
+		_N( 2005_2, 20, 58 ) \
+		_N( 2003_2, 17, 56 ) \
+		_N( 2002_2, 14, 55 ) \
+		_N( 2002_1, 13, 54 ) \
+		_N( 2001_2, 12, 52 ) \
+		_N( 2001_1, 11, 51 ) \
+
+	struct DepotProtocol
+	{
+		#define DEPOT_PROTOCOL_LEVEL_INFO(name, server, client) \
+			static constexpr int32_t SERVER_##name = server; \
+			static constexpr int32_t CLIENT_##name = client; \
+			static constexpr char* SERVER_##name##_STRING = #server; \
+			static constexpr char* CLIENT_##name##_STRING = #client;
+		DEPOT_PROTOCOL_LEVELS(DEPOT_PROTOCOL_LEVEL_INFO)
+		#undef DEPOT_PROTOCOL_LEVEL_INFO
+
+		static constexpr int32_t SERVER_ALT_SYNC = SERVER_2023_1;
+		static constexpr int32_t SERVER_SIZES_C = SERVER_2023_1;
+	};
+	
 }}}
 
 #pragma managed(pop)

--- a/source/P4VFS.Core/Include/DepotOperations.h
+++ b/source/P4VFS.Core/Include/DepotOperations.h
@@ -20,7 +20,7 @@ namespace P4 {
 			DepotClient& depotClient, 
 			const DepotStringArray& files, 
 			const DepotRevision revision = nullptr,
-			DepotSyncType::Enum syncType = DepotSyncType::Normal,
+			DepotSyncFlags::Enum syncFlags = DepotSyncFlags::Normal,
 			DepotSyncMethod::Enum syncMethod = DepotSyncMethod::Virtual, 
 			DepotFlushType::Enum flushType = DepotFlushType::Atomic,  
 			const DepotString& syncResident = DepotString()
@@ -117,7 +117,7 @@ namespace P4 {
 			DepotClient& depotClient, 
 			const DepotStringArray& files, 
 			DepotRevision revision,
-			DepotSyncType::Enum syncType,
+			DepotSyncFlags::Enum syncFlags,
 			FileCore::LogDevice* log = nullptr
 			);
 

--- a/source/P4VFS.Core/Include/DepotOperations.h
+++ b/source/P4VFS.Core/Include/DepotOperations.h
@@ -6,6 +6,7 @@
 #include "DepotDateTime.h"
 #include "DepotResultDiff2.h"
 #include "DepotResultFStat.h"
+#include "DepotResultSizes.h"
 #include "DepotReconfig.h"
 #pragma managed(push, off)
 
@@ -160,6 +161,18 @@ namespace P4 {
 			const DepotString& filterType = DepotString(),
 			FDepotResultFStatField::Enum fields = FDepotResultFStatField::Default, 
 			const DepotStringArray& optionArgs = DepotStringArray()
+			);
+
+		struct SizesFlags { enum Enum {
+			None			= 0,
+			ClientSize		= 1<<0,
+		};};
+
+		static DepotResultSizes
+		Sizes(
+			DepotClient& depotClient,
+			const DepotString& fileSpec, 
+			SizesFlags::Enum flags = SizesFlags::None
 			);
 
 		static bool

--- a/source/P4VFS.Core/Include/DepotResultSizes.h
+++ b/source/P4VFS.Core/Include/DepotResultSizes.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+#pragma once
+#include "DepotResult.h"
+#pragma managed(push, off)
+
+namespace Microsoft {
+namespace P4VFS {
+namespace P4 {
+
+	struct FDepotResultSizesField
+	{
+		struct Name
+		{
+			static constexpr const char* DepotFile 		= "depotFile";
+			static constexpr const char* FileSize 		= "fileSize";
+			static constexpr const char* FileCount		= "fileCount";
+			static constexpr const char* Path			= "path";
+			static constexpr const char* Rev			= "rev";
+		};
+	};
+
+	struct FDepotResultSizesNode : FDepotResultNode
+	{
+		const DepotString& DepotFile() 			{ return GetTagValue(FDepotResultSizesField::Name::DepotFile); }
+		int64_t FileSize() 						{ return Tag().GetValueInt64(FDepotResultSizesField::Name::FileSize); }
+		int64_t FileCount() 					{ return Tag().GetValueInt64(FDepotResultSizesField::Name::FileCount); }
+		const DepotString& Path() 				{ return GetTagValue(FDepotResultSizesField::Name::Path); }
+		int32_t Rev()							{ return Tag().GetValueInt32(FDepotResultSizesField::Name::Rev); }
+	};
+
+	typedef FDepotResultNodeProvider<FDepotResultSizesNode> FDepotResultSizes;
+	typedef std::shared_ptr<FDepotResultSizes> DepotResultSizes;
+
+}}}
+
+#pragma managed(pop)

--- a/source/P4VFS.Core/Include/DepotSyncAction.h
+++ b/source/P4VFS.Core/Include/DepotSyncAction.h
@@ -20,6 +20,7 @@ namespace P4 {
 			IgnoreOutput	= 1<<3,
 			Quiet			= 1<<4,
 			Writeable		= 1<<5,
+			ClientSize		= 1<<6,
 		};
 
 		P4VFS_CORE_API static DepotString ToString(Enum value);

--- a/source/P4VFS.Core/Include/DepotSyncAction.h
+++ b/source/P4VFS.Core/Include/DepotSyncAction.h
@@ -9,7 +9,7 @@ namespace Microsoft {
 namespace P4VFS {
 namespace P4 {
 
-	struct DepotSyncType
+	struct DepotSyncFlags
 	{
 		enum Enum
 		{
@@ -93,7 +93,7 @@ namespace P4 {
 		DepotRevision m_Revision;
 		DepotSyncActionType::Enum m_SyncActionType;
 		DepotSyncActionFlags::Enum m_SyncActionFlags;
-		DepotSyncType::Enum m_SyncType;
+		DepotSyncFlags::Enum m_SyncFlags;
 		DepotFlushType::Enum m_FlushType;
 		int64_t m_DiskFileSize;
 		int64_t m_VirtualFileSize;
@@ -145,7 +145,7 @@ namespace P4 {
 
 	typedef std::shared_ptr<FDepotSyncResult> DepotSyncResult;
 
-	DEFINE_ENUM_FLAG_OPERATORS(DepotSyncType::Enum);
+	DEFINE_ENUM_FLAG_OPERATORS(DepotSyncFlags::Enum);
 	DEFINE_ENUM_FLAG_OPERATORS(DepotSyncActionFlags::Enum);
 	DEFINE_ENUM_FLAG_OPERATORS(DepotSyncStatus::Enum);
 }}}

--- a/source/P4VFS.Core/Include/DepotSyncOptions.h
+++ b/source/P4VFS.Core/Include/DepotSyncOptions.h
@@ -24,7 +24,7 @@ namespace P4 {
 	{
 		DepotStringArray m_Files;
 		DepotRevision m_Revision;
-		DepotSyncType::Enum m_SyncType;
+		DepotSyncFlags::Enum m_SyncFlags;
 		DepotFlushType::Enum m_FlushType;
 		DepotSyncMethod::Enum m_SyncMethod;
 		DepotString m_SyncResident;

--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -66,8 +66,8 @@ namespace FileCore {
 	template <typename KeyType, typename LessType = std::less<KeyType>>
 	using Set = std::set<KeyType, LessType>;
 
-	template <typename KeyType>
-	using HashSet = std::unordered_set<KeyType, std::hash<KeyType>, std::equal_to<KeyType>>;
+	template <typename KeyType, typename EqualType = std::equal_to<KeyType>>
+	using HashSet = std::unordered_set<KeyType, std::hash<KeyType>, EqualType>;
 
 	template <typename ValueType>
 	using Array = std::vector<ValueType>;
@@ -591,8 +591,8 @@ namespace FileCore {
 			return std::find(elements.begin(), elements.end(), v) != elements.end();
 		}
 
-		template <typename KeyType>
-		static bool Contains(const HashSet<KeyType>& elements, const KeyType& v)
+		template <typename KeyType, typename EqualType>
+		static bool Contains(const HashSet<KeyType, EqualType>& elements, const KeyType& v)
 		{
 			return elements.find(v) != elements.end();
 		}

--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -691,6 +691,7 @@ namespace FileCore {
 			HideWindow	= (1<<1),
 			StdOut		= (1<<2),
 			KeepOpen	= (1<<3),
+			Unelevated	= (1<<4),
 			Default		= WaitForExit,
 		};};
 

--- a/source/P4VFS.Core/P4VFS.Core.vcxproj
+++ b/source/P4VFS.Core/P4VFS.Core.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="Include\DepotResultFStat.h" />
     <ClInclude Include="Include\DepotResultInfo.h" />
     <ClInclude Include="Include\DepotResultPrint.h" />
+    <ClInclude Include="Include\DepotResultSizes.h" />
     <ClInclude Include="Include\DepotResultWhere.h" />
     <ClInclude Include="Include\DepotRevision.h" />
     <ClInclude Include="Include\DepotSyncAction.h" />

--- a/source/P4VFS.Core/P4VFS.Core.vcxproj.filters
+++ b/source/P4VFS.Core/P4VFS.Core.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClInclude Include="Include\DepotReconfig.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="Include\DepotResultSizes.h">
+      <Filter>Include</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource\Core.rc">

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -441,7 +441,7 @@ bool FDepotClient::Connect(const DepotConfig& config)
 	m_P4->m_ClientApi->SetProg(GetProgramName().c_str());
 	m_P4->m_ClientApi->SetTicketFile(GetTicketsFilePath().c_str());
 	m_P4->m_ClientApi->SetTrustFile(GetTrustFilePath().c_str());
-	m_P4->m_ClientApi->SetProtocol(P4Tag::v_api, "70"); // 2016.1
+	m_P4->m_ClientApi->SetProtocol(P4Tag::v_api, DepotProtocol::CLIENT_2016_1_STRING);
 	m_P4->m_ClientApi->SetProtocol(P4Tag::v_specstring, ""); 
 	m_P4->m_ClientApi->SetProtocol(P4Tag::v_enableStreams, "");
 
@@ -573,6 +573,18 @@ DepotString FDepotClient::GetErrorText()
 		text = FileCore::StringInfo::ToString(msg.Text());
 	}
 	return text;
+}
+
+int32_t FDepotClient::GetServerProtocol()
+{
+	if (m_P4->m_ClientApi.get())
+	{
+		if (const StrPtr* server2 = m_P4->m_ClientApi->GetProtocol(P4Tag::v_server2))
+		{
+			return server2->Atoi();
+		}
+	}
+	return 0;
 }
 
 DepotString FDepotClient::GetProgramName() const

--- a/source/P4VFS.Core/Source/DepotOperations.cpp
+++ b/source/P4VFS.Core/Source/DepotOperations.cpp
@@ -986,6 +986,15 @@ DepotOperations::SyncCommand(
 				modification->m_Revision = FDepotRevision::New<FDepotRevisionNumber>(fstatNode->HeadRev());
 			}
 		}
+
+		if (FDepotResultSizesNode* sizesNode = Algo::Find(depotFileClientSizeMap, modification->m_DepotFile))
+		{
+			int64_t clientFileSize = sizesNode->FileSize();
+			if (clientFileSize > 0)
+			{
+				modification->m_FileSize = clientFileSize;
+			}
+		}
 	}
 
 	if (syncFlags & (DepotSyncFlags::Preview | DepotSyncFlags::Flush))

--- a/source/P4VFS.Core/Source/DepotSyncAction.cpp
+++ b/source/P4VFS.Core/Source/DepotSyncAction.cpp
@@ -8,16 +8,16 @@ namespace Microsoft {
 namespace P4VFS {
 namespace P4 {
 
-DepotString DepotSyncType::ToString(DepotSyncType::Enum value)
+DepotString DepotSyncFlags::ToString(DepotSyncFlags::Enum value)
 {
 	DepotString result;
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, Normal);
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, Force);
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, Flush);
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, Preview);
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, IgnoreOutput);
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, Quiet);
-	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncType, Writeable);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Normal);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Force);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Flush);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Preview);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, IgnoreOutput);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Quiet);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Writeable);
 	return result;
 }
 
@@ -130,7 +130,7 @@ FDepotSyncActionInfo::FDepotSyncActionInfo() :
 	m_Revision(),
 	m_SyncActionType(DepotSyncActionType::None),
 	m_SyncActionFlags(DepotSyncActionFlags::None),
-	m_SyncType(DepotSyncType::Normal),
+	m_SyncFlags(DepotSyncFlags::Normal),
 	m_FlushType(DepotFlushType::Atomic),
 	m_DiskFileSize(0),
 	m_VirtualFileSize(0),
@@ -155,7 +155,7 @@ int32_t FDepotSyncActionInfo::RevisionNumber() const
 
 bool FDepotSyncActionInfo::CanModifyWritableFile() const
 {
-	if (m_SyncType & DepotSyncType::Force)
+	if (m_SyncFlags & DepotSyncFlags::Force)
 		return true;
 	if (m_SyncActionFlags & (DepotSyncActionFlags::ClientClobber | DepotSyncActionFlags::ClientWrite | DepotSyncActionFlags::FileWrite | DepotSyncActionFlags::HaveFileWrite | DepotSyncActionFlags::FileSymlink))
 		return true;
@@ -171,7 +171,7 @@ bool FDepotSyncActionInfo::CanSetWritableFile() const
 
 bool FDepotSyncActionInfo::IsPreview() const
 {
-	if (m_SyncType & DepotSyncType::Preview)
+	if (m_SyncFlags & DepotSyncFlags::Preview)
 		return true;
 	return false;
 }

--- a/source/P4VFS.Core/Source/DepotSyncAction.cpp
+++ b/source/P4VFS.Core/Source/DepotSyncAction.cpp
@@ -18,6 +18,7 @@ DepotString DepotSyncFlags::ToString(DepotSyncFlags::Enum value)
 	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, IgnoreOutput);
 	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Quiet);
 	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, Writeable);
+	P4VFS_ENUM_TO_STRING_APPEND_FLAG(result, value, DepotSyncFlags, ClientSize);
 	return result;
 }
 

--- a/source/P4VFS.Core/Source/DepotSyncOptions.cpp
+++ b/source/P4VFS.Core/Source/DepotSyncOptions.cpp
@@ -15,7 +15,7 @@ DepotString DepotSyncMethod::ToString(DepotSyncMethod::Enum value)
 }
 
 FDepotSyncOptions::FDepotSyncOptions() :
-	m_SyncType(DepotSyncType::Normal),
+	m_SyncFlags(DepotSyncFlags::Normal),
 	m_SyncMethod(DepotSyncMethod::Virtual),
 	m_FlushType(DepotFlushType::Atomic)
 {

--- a/source/P4VFS.Core/Source/FileAssert.cpp
+++ b/source/P4VFS.Core/Source/FileAssert.cpp
@@ -22,16 +22,20 @@ namespace FileCore {
 
 		msg += StringInfo::Format(TEXT("%s(%d): [%s]\n"), file, line, expr);
 		if (IsDebuggerPresent())
+		{
 			OutputDebugString(msg.c_str());
+		}
 
 		AssertDebugBreak();
-		throw new std::exception(StringInfo::WtoA(msg));
+		throw std::exception(StringInfo::WtoA(msg));
 	}
 
 	void AssertDebugBreakImpl()
 	{
 		if (IsDebuggerPresent()) 
+		{
 			__debugbreak(); 
+		}
 	}
 
 }}}

--- a/source/P4VFS.Core/Tests/TestDepotOperations.cpp
+++ b/source/P4VFS.Core/Tests/TestDepotOperations.cpp
@@ -39,12 +39,12 @@ void TestDepotOperationsSync(const TestContext& context)
 
 	for (DepotSyncMethod::Enum syncMethod : { DepotSyncMethod::Virtual, DepotSyncMethod::Regular })
 	{
-		for (DepotSyncType::Enum syncType : { DepotSyncType::Normal, DepotSyncType::Quiet })
+		for (DepotSyncFlags::Enum syncFlags : { DepotSyncFlags::Normal, DepotSyncFlags::Quiet })
 		{
 			TestUtilities::WorkspaceReset(context);
 			for (const char* fileSpec : fileSpecs)
 			{
-				DepotSyncResult syncResult = DepotOperations::Sync(client, DepotStringArray{ fileSpec }, nullptr, syncType, syncMethod);
+				DepotSyncResult syncResult = DepotOperations::Sync(client, DepotStringArray{ fileSpec }, nullptr, syncFlags, syncMethod);
 				Assert(syncResult.get() != nullptr);
 				Assert(syncResult->m_Status == DepotSyncStatus::Success);
 				Assert(syncResult->m_Modifications.get() && syncResult->m_Modifications->size() > 0);
@@ -64,9 +64,9 @@ void TestDepotOperationsSyncStatus(const TestContext& context)
 	{
 		for (DepotSyncMethod::Enum syncMethod : { DepotSyncMethod::Virtual, DepotSyncMethod::Regular })
 		{
-			for (DepotSyncType::Enum syncType : { DepotSyncType::Normal, DepotSyncType::Quiet })
+			for (DepotSyncFlags::Enum syncFlags : { DepotSyncFlags::Normal, DepotSyncFlags::Quiet })
 			{
-				DepotSyncResult syncResult = DepotOperations::Sync(client, DepotStringArray{ fileSpec }, nullptr, syncType, syncMethod);
+				DepotSyncResult syncResult = DepotOperations::Sync(client, DepotStringArray{ fileSpec }, nullptr, syncFlags, syncMethod);
 				Assert(syncResult.get() != nullptr);
 				Assert(syncResult->m_Status == status);
 				Assert((modificationCount < 0 && syncResult->m_Modifications.get() == nullptr) || (syncResult->m_Modifications.get() && int32_t(syncResult->m_Modifications->size()) == modificationCount));
@@ -97,11 +97,11 @@ void TestDepotOperationsToString(const TestContext& context)
 	Assert(DepotOperations::ToString(DepotStringArray{"//foo/bar", "//foo/star"}) == "[\"//foo/bar\",\"//foo/star\"]");
 	Assert(DepotOperations::ToString(DepotStringArray{"//foo/bar", ""}) == "[\"//foo/bar\",\"\"]");
 
-	Assert(DepotSyncType::ToString(DepotSyncType::Flush) == "Flush");
-	Assert(DepotSyncType::ToString(DepotSyncType::Enum(DepotSyncType::Flush|DepotSyncType::Quiet)) == "Flush|Quiet");
-	Assert(DepotSyncType::ToString(DepotSyncType::Enum(DepotSyncType::Flush|DepotSyncType::Quiet|DepotSyncType::IgnoreOutput)) == "Flush|IgnoreOutput|Quiet");
-	Assert(DepotSyncType::ToString(DepotSyncType::Enum(0)) == "Normal");
-	Assert(DepotSyncType::ToString(DepotSyncType::Enum(1<<16)) == "");
+	Assert(DepotSyncFlags::ToString(DepotSyncFlags::Flush) == "Flush");
+	Assert(DepotSyncFlags::ToString(DepotSyncFlags::Enum(DepotSyncFlags::Flush|DepotSyncFlags::Quiet)) == "Flush|Quiet");
+	Assert(DepotSyncFlags::ToString(DepotSyncFlags::Enum(DepotSyncFlags::Flush|DepotSyncFlags::Quiet|DepotSyncFlags::IgnoreOutput)) == "Flush|IgnoreOutput|Quiet");
+	Assert(DepotSyncFlags::ToString(DepotSyncFlags::Enum(0)) == "Normal");
+	Assert(DepotSyncFlags::ToString(DepotSyncFlags::Enum(1<<16)) == "");
 
 	Assert(DepotSyncMethod::ToString(DepotSyncMethod::Regular) == "Regular");
 	Assert(DepotSyncMethod::ToString(DepotSyncMethod::Virtual) == "Virtual");

--- a/source/P4VFS.Core/Tests/TestDirectoryOperations.cpp
+++ b/source/P4VFS.Core/Tests/TestDirectoryOperations.cpp
@@ -81,7 +81,7 @@ void TestIterateDirectoryParallel(const TestContext& context)
 	Assert(client->Connect(context.GetDepotConfig()));
 	
 	FDepotSyncOptions syncOptions;
-	syncOptions.m_SyncType = DepotSyncType::Quiet;
+	syncOptions.m_SyncFlags = DepotSyncFlags::Quiet;
 	DepotSyncResult syncResult = DepotOperations::Sync(client, syncOptions);
 	Assert(syncResult.get() != nullptr);
 	Assert(syncResult->m_Status == DepotSyncStatus::Success);

--- a/source/P4VFS.Core/Tests/TestFactory.cpp
+++ b/source/P4VFS.Core/Tests/TestFactory.cpp
@@ -132,42 +132,27 @@ namespace TestCore {
 		context.m_WorkspaceReset();
 	}
 
-	DWORD TestUtilities::ExecuteWait(const FileCore::String& cmd, FileCore::String* stdOutput)
+	DWORD TestUtilities::ExecuteWait(const TestContext& context, const FileCore::String& cmd, FileCore::String* stdOutput, FileCore::Process::ExecuteFlags::Enum flags)
 	{
-		using namespace FileCore;
 		if (cmd.empty())
 		{
 			return DWORD(-1);
 		}
 
-		Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::HideWindow | Process::ExecuteFlags::WaitForExit;
+		context.Log()->Info(cmd.c_str());
+
+		flags |= FileCore::Process::ExecuteFlags::HideWindow | FileCore::Process::ExecuteFlags::WaitForExit;
 		if (stdOutput != nullptr)
 		{
-			flags |= Process::ExecuteFlags::StdOut;
+			flags |= FileCore::Process::ExecuteFlags::StdOut;
 		}
 
-		Process::ExecuteResult result = Process::Execute(cmd.c_str(), nullptr, flags);
+		FileCore::Process::ExecuteResult result = FileCore::Process::Execute(cmd.c_str(), nullptr, flags);
 		if (stdOutput != nullptr)
 		{
 			stdOutput->assign(StringInfo::ToWide(result.m_StdOut));
 		}
 		return result.m_ExitCode;
-	}
-
-	DWORD TestUtilities::ExecuteLogWait(const FileCore::String& cmd, const TestContext& context, const wchar_t* logLinePrefix)
-	{
-		FileCore::String stdOutput;
-		DWORD exitCode = ExecuteWait(cmd, &stdOutput);
-
-		FileCore::StringArray logLines = StringInfo::Split(stdOutput.c_str(), TEXT("\n"), StringInfo::SplitFlags::None);
-		for (const String& logLine : logLines)
-		{
-			String logLineOut(logLinePrefix ? logLinePrefix : TEXT(""));
-			logLineOut += logLine;
-			context.Log()->Info(StringInfo::TrimRight(logLineOut.c_str()));
-		}
-		
-		return exitCode;
 	}
 }}}
 

--- a/source/P4VFS.Core/Tests/TestFactory.h
+++ b/source/P4VFS.Core/Tests/TestFactory.h
@@ -86,7 +86,8 @@ namespace TestCore {
 	struct P4VFS_CORE_API TestUtilities
 	{
 		static void WorkspaceReset(const TestContext& context);
-		static DWORD ExecuteWait(const FileCore::String& fileName, const FileCore::String& args, FileCore::String* stdOutput = nullptr);
+		static DWORD ExecuteWait(const FileCore::String& cmd, FileCore::String* stdOutput = nullptr);
+		static DWORD ExecuteLogWait(const FileCore::String& cmd, const TestContext& context, const wchar_t* logLinePrefix = nullptr);
 	};
 }}}
 
@@ -98,5 +99,12 @@ namespace TestCore {
 		return Microsoft::P4VFS::TestCore::TestObject(TEXT(#name), TEXT(__FILE__), priority, &name, __VA_ARGS__); \
 	} \
 	static Microsoft::P4VFS::TestCore::TestRegistrator TestRegistrator##name(&TestFactoryCreateTestObject##name); \
+
+#define P4VFS_FIND_TEST(name) \
+	([]() -> Microsoft::P4VFS::TestCore::TestObject \
+	{ \
+		extern Microsoft::P4VFS::TestCore::TestObject TestFactoryCreateTestObject##name(); \
+		return TestFactoryCreateTestObject##name(); \
+	})()
 
 #pragma managed(pop)

--- a/source/P4VFS.Core/Tests/TestFactory.h
+++ b/source/P4VFS.Core/Tests/TestFactory.h
@@ -35,15 +35,26 @@ namespace TestCore {
 
 	typedef void (*TestDelegate)(const TestContext& context);
 
+	struct TestFlags 
+	{
+		enum Enum
+		{
+			None		= 0,
+			Explicit	= 1<<0,
+		};
+	};
+
+	DEFINE_ENUM_FLAG_OPERATORS(TestFlags::Enum);
+
 	struct TestObject
 	{	
-		TestObject(const wchar_t* name, const wchar_t* filename, int32_t priority);
-		TestObject(const wchar_t* name, const wchar_t* filename, int32_t priority, TestDelegate exec);
+		TestObject(const wchar_t* name, const wchar_t* filename, int32_t priority, TestDelegate exec, TestFlags::Enum flags = TestFlags::None);
 
 		String m_Name;
 		String m_Filename;
 		int32_t m_Priority;
 		TestDelegate m_Exec;
+		TestFlags::Enum m_Flags;
 	};
 
 	typedef TestObject (*TestObjectCreator)();
@@ -79,11 +90,12 @@ namespace TestCore {
 	};
 }}}
 
-#define P4VFS_REGISTER_TEST(name, priority) \
+#define P4VFS_REGISTER_TEST(name, priority, ...) \
 	__declspec(dllexport) Microsoft::P4VFS::TestCore::TestObject TestFactoryCreateTestObject##name() \
 	{ \
+		using namespace Microsoft::P4VFS::TestCore; \
 		extern void name(const Microsoft::P4VFS::TestCore::TestContext&); \
-		return Microsoft::P4VFS::TestCore::TestObject(TEXT(#name), TEXT(__FILE__), priority, &name); \
+		return Microsoft::P4VFS::TestCore::TestObject(TEXT(#name), TEXT(__FILE__), priority, &name, __VA_ARGS__); \
 	} \
 	static Microsoft::P4VFS::TestCore::TestRegistrator TestRegistrator##name(&TestFactoryCreateTestObject##name); \
 

--- a/source/P4VFS.Core/Tests/TestFactory.h
+++ b/source/P4VFS.Core/Tests/TestFactory.h
@@ -86,8 +86,7 @@ namespace TestCore {
 	struct P4VFS_CORE_API TestUtilities
 	{
 		static void WorkspaceReset(const TestContext& context);
-		static DWORD ExecuteWait(const FileCore::String& cmd, FileCore::String* stdOutput = nullptr);
-		static DWORD ExecuteLogWait(const FileCore::String& cmd, const TestContext& context, const wchar_t* logLinePrefix = nullptr);
+		static DWORD ExecuteWait(const TestContext& context, const FileCore::String& cmd, FileCore::String* stdOutput = nullptr, FileCore::Process::ExecuteFlags::Enum flags = FileCore::Process::ExecuteFlags::None);
 	};
 }}}
 

--- a/source/P4VFS.Core/Tests/TestFileOperations.cpp
+++ b/source/P4VFS.Core/Tests/TestFileOperations.cpp
@@ -85,11 +85,6 @@ void TestFileOperationsOpenReparsePointFile(const TestContext& context)
 	Assert(memcmp(localFileReadBytes.data(), localFileWriteBytes.data(), localFileWriteBytes.size()) == 0);
 }
 
-static int32_t ExecCmd(const String& Cmd)
-{
-	return Process::Execute(Cmd.c_str(), nullptr, Process::ExecuteFlags::HideWindow|Process::ExecuteFlags::WaitForExit).m_ExitCode;
-}
-
 void TestFileOperationsAccess(const TestContext& context)
 {
 	const String p4vfsExe = context.GetEnvironment(TEXT("P4VFS_EXE"));
@@ -99,30 +94,48 @@ void TestFileOperationsAccess(const TestContext& context)
 	const String psexecExe = StringInfo::Format(TEXT("%s\\psexec.exe"), sysInternalsFolder.c_str());
 	Assert(FileInfo::IsRegular(psexecExe.c_str()));
 
-	Assert(ExecCmd(TEXT("fltmc.exe")) == 0);
-	Assert(ExecCmd(StringInfo::Format(TEXT("\"%s\" -i -accepteula -nobanner fltmc.exe"), psexecExe.c_str())) == 0);
-	Assert(ExecCmd(StringInfo::Format(TEXT("\"%s\" -i -l -accepteula -nobanner fltmc.exe"), psexecExe.c_str())) != 0);
+	// Confirm successfull run of elevated process
+	Assert(TestUtilities::ExecuteWait(TEXT("fltmc.exe")) == 0);
+	// Confirm successfull psexec run of elevated process
+	Assert(TestUtilities::ExecuteWait(StringInfo::Format(TEXT("\"%s\" -i -accepteula -nobanner fltmc.exe"), psexecExe.c_str())) == 0);
+	// Confirm unsuccessfull psexec run of unelevated process
+	Assert(TestUtilities::ExecuteWait(StringInfo::Format(TEXT("\"%s\" -i -l -accepteula -nobanner fltmc.exe"), psexecExe.c_str())) != 0);
 
-	Assert(ExecCmd(StringInfo::Format(TEXT("\"%s\" test 11003"), p4vfsExe.c_str())) == 0);
-	Assert(ExecCmd(StringInfo::Format(TEXT("\"%s\" -i -l -accepteula -nobanner \"%s\" test 11004"), psexecExe.c_str(), p4vfsExe.c_str())) == 0);
+	// Confirm successfull run of p4vfs test TestFileOperationsAccessElevated
+	int32_t testElevatedPriority = P4VFS_FIND_TEST(TestFileOperationsAccessElevated).m_Priority;
+	Assert(TestUtilities::ExecuteLogWait(StringInfo::Format(TEXT("\"%s\" -b test -e %d"), p4vfsExe.c_str(), testElevatedPriority), context, TEXT("[AccessElevated] ")) == 0);
+
+	// Confirm successfull run of p4vfs test TestFileOperationsAccessUnelevated
+	int32_t testUnelevatedPriority = P4VFS_FIND_TEST(TestFileOperationsAccessUnelevated).m_Priority;
+	Assert(TestUtilities::ExecuteLogWait(StringInfo::Format(TEXT("\"%s\" -i -l -accepteula -nobanner \"%s\" -b test -e %d"), psexecExe.c_str(), p4vfsExe.c_str(), testUnelevatedPriority), context, TEXT("[AccessUnelevated] ")) == 0);
+}
+
+void AssertFileOperationsAccessInternal(const TestContext& context, bool isElevated)
+{
+	// Confirm successfull run of elevated process if expected
+	Assert((TestUtilities::ExecuteWait(TEXT("fltmc.exe")) == 0) == isElevated);
+
+	// Attempt to open read/write an an existing file under an elevation protected folder
+	const String adminFilePath = FileOperations::GetExpandedEnvironmentStrings(TEXT("%ProgramFiles%\\P4VFS\\P4VFS.Notes.txt"));
+	Assert(FileInfo::IsRegular(adminFilePath.c_str()));
+	P4VFS_FLT_FILE_HANDLE adminFileHandle = FileOperations::OpenReparsePointFile(adminFilePath.c_str(), FILE_GENERIC_READ|FILE_GENERIC_WRITE, 0);
+	if (isElevated)
+	{
+		Assert(adminFileHandle.fileHandle != NULL && adminFileHandle.fileHandle != INVALID_HANDLE_VALUE && adminFileHandle.fileObject != nullptr);
+		Assert(SUCCEEDED(FileOperations::CloseReparsePointFile(adminFileHandle)));
+	}
+	else
+	{
+		Assert(adminFileHandle.fileHandle == NULL && adminFileHandle.fileObject == nullptr);
+	}
 }
 
 void TestFileOperationsAccessElevated(const TestContext& context)
 {
-	Assert(ExecCmd(TEXT("fltmc.exe")) == 0);
-
-/*
-	const WCHAR* adminFilePath = TEXT("C:\Program Files\P4VFS\P4VFS.Notes.txt");
-	P4VFS_FLT_FILE_HANDLE adminHandleWrite = FileOperations::OpenReparsePointFile(adminFilePath, FILE_GENERIC_READ|FILE_GENERIC_WRITE, 0);
-	Assert(adminHandleWrite.fileHandle == NULL && adminHandleWrite.fileObject == nullptr);
-
-	P4VFS_FLT_FILE_HANDLE adminHandleRead = FileOperations::OpenReparsePointFile(adminFilePath, FILE_GENERIC_READ, 0);
-	Assert(adminHandleRead.fileHandle != NULL && adminHandleRead.fileHandle != INVALID_HANDLE_VALUE && adminHandleRead.fileObject != nullptr);
-	Assert(SUCCEEDED(FileOperations::CloseReparsePointFile(adminHandleRead)));
-*/
+	AssertFileOperationsAccessInternal(context, true);
 }
 
 void TestFileOperationsAccessUnelevated(const TestContext& context)
 {
-	Assert(ExecCmd(TEXT("fltmc.exe")) != 0);
+	AssertFileOperationsAccessInternal(context, false);
 }

--- a/source/P4VFS.Core/Tests/TestFileSystem.cpp
+++ b/source/P4VFS.Core/Tests/TestFileSystem.cpp
@@ -162,7 +162,7 @@ void TestFileAlternateStream(const TestContext& context)
 
 	auto AssertForceSyncFile = [&]() -> void
 	{
-		DepotSyncResult syncResult = DepotOperations::Sync(client, DepotStringArray{ depotFile }, nullptr, DepotSyncType::Force);
+		DepotSyncResult syncResult = DepotOperations::Sync(client, DepotStringArray{ depotFile }, nullptr, DepotSyncFlags::Force);
 		Assert(syncResult.get() && syncResult->m_Status == DepotSyncStatus::Success);
 		Assert(FileInfo::IsRegular(clientFile.c_str()));
 		Assert(context.m_IsPlaceholderFile(clientFile));

--- a/source/P4VFS.Core/Tests/TestFileSystem.cpp
+++ b/source/P4VFS.Core/Tests/TestFileSystem.cpp
@@ -21,7 +21,7 @@ void TestResolveFileResidency(const TestContext& context)
 		const String p4Options = context.GetEnvironment(L"P4VFS_EXE_CONFIG");
 		Assert(p4Options.empty() == false);
 
-		Assert(TestUtilities::ExecuteWait(StringInfo::Format(L"\"%s\" %s sync -f %s", p4vfsExe.c_str(), p4Options.c_str(), depotFile.c_str())) == 0);
+		Assert(TestUtilities::ExecuteWait(context, StringInfo::Format(L"\"%s\" %s sync -f %s", p4vfsExe.c_str(), p4Options.c_str(), depotFile.c_str())) == 0);
 		const String clientFile = StringInfo::ToWide(client.Run<DepotResultWhere>("where", DepotStringArray{ StringInfo::ToAnsi(depotFile) })->Node().LocalPath());
 		Assert(FileInfo::IsRegular(clientFile.c_str()));
 		Assert(context.m_IsPlaceholderFile(clientFile));

--- a/source/P4VFS.Core/Tests/TestFileSystem.cpp
+++ b/source/P4VFS.Core/Tests/TestFileSystem.cpp
@@ -21,7 +21,7 @@ void TestResolveFileResidency(const TestContext& context)
 		const String p4Options = context.GetEnvironment(L"P4VFS_EXE_CONFIG");
 		Assert(p4Options.empty() == false);
 
-		Assert(TestUtilities::ExecuteWait(p4vfsExe, StringInfo::Format(L"%s sync -f %s", p4Options.c_str(), depotFile.c_str())) == 0);
+		Assert(TestUtilities::ExecuteWait(StringInfo::Format(L"\"%s\" %s sync -f %s", p4vfsExe.c_str(), p4Options.c_str(), depotFile.c_str())) == 0);
 		const String clientFile = StringInfo::ToWide(client.Run<DepotResultWhere>("where", DepotStringArray{ StringInfo::ToAnsi(depotFile) })->Node().LocalPath());
 		Assert(FileInfo::IsRegular(clientFile.c_str()));
 		Assert(context.m_IsPlaceholderFile(clientFile));

--- a/source/P4VFS.Core/Tests/TestRegistry.cpp
+++ b/source/P4VFS.Core/Tests/TestRegistry.cpp
@@ -57,6 +57,9 @@ P4VFS_REGISTER_TEST( TestDriverUnicodeString,					10900 )
 // TestFileOperations
 P4VFS_REGISTER_TEST( TestFileOperationsUnicodeString,			11000 )
 P4VFS_REGISTER_TEST( TestFileOperationsOpenReparsePointFile,	11001 )
+P4VFS_REGISTER_TEST( TestFileOperationsAccess,					11002 )
+P4VFS_REGISTER_TEST( TestFileOperationsAccessElevated,			11003, TestFlags::Explicit )
+P4VFS_REGISTER_TEST( TestFileOperationsAccessUnelevated,		11004, TestFlags::Explicit )
 
 // TestDirectoryOperations
 P4VFS_REGISTER_TEST( TestIterateDirectoryParallel,				12000 )

--- a/source/P4VFS.CoreInterop/Include/CoreInterop.h
+++ b/source/P4VFS.CoreInterop/Include/CoreInterop.h
@@ -142,53 +142,53 @@ public:
 
 	static System::Int32 
 	InstallReparsePointOnFile(
-		System::UInt16		majorVersion,
-		System::UInt16		minorVersion,
-		System::UInt16		buildVersion,
-		System::String^		filePath,
-		System::Byte		residencyPolicy,
-		System::UInt32		fileRevision,
-		System::Int64		fileSize,
-		System::UInt32		fileAttributes,
-		System::String^		depotPath,
-		System::String^		depotServer,
-		System::String^		depotClient,
-		System::String^		depotUser
+		System::UInt16 majorVersion,
+		System::UInt16 minorVersion,
+		System::UInt16 buildVersion,
+		System::String^ filePath,
+		System::Byte residencyPolicy,
+		System::UInt32 fileRevision,
+		System::Int64 fileSize,
+		System::UInt32 fileAttributes,
+		System::String^ depotPath,
+		System::String^ depotServer,
+		System::String^ depotClient,
+		System::String^ depotUser
 		);
 
 	static System::Int32
 	CreateSymlinkFile(
-		System::String^		symlinkFilePath,
-		System::String^		targetFilePath
+		System::String^ symlinkFilePath,
+		System::String^ targetFilePath
 	);
 
 	static System::Int32 
 	RemoveReparsePoint(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Int32 
 	PopulateFile(
-		System::String^		dstFile,
-		System::String^		srcFile,
-		FilePopulateMethod	populateMethod
+		System::String^ dstFile,
+		System::String^ srcFile,
+		FilePopulateMethod populateMethod
 		);
 
 	static System::Int32 
 	HydrateFile(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	ImpersonateFileAppend(
-		System::String^		filePath,
-		System::String^		text,
-		UserContext^		context
+		System::String^ filePath,
+		System::String^ text,
+		UserContext^ context
 		);
 
 	static System::Boolean
 	ImpersonateLoggedOnUser(
-		UserContext^	context
+		UserContext^ context
 		);
 
 	static System::Boolean
@@ -197,18 +197,18 @@ public:
 
 	static System::String^
 	GetImpersonatedUserName(
-		UserContext^	context
+		UserContext^ context
 		);
 
 	static System::String^
 	GetImpersonatedEnvironmentStrings(
-		System::String^	srcText,
-		UserContext^	context
+		System::String^ srcText,
+		UserContext^ context
 		);
 
 	static System::IntPtr^
 	GetLoggedOnUserToken(
-		UserContext^	context
+		UserContext^ context
 		);
 
 	static System::IntPtr^
@@ -217,112 +217,112 @@ public:
 
 	static System::Boolean
 	CreateProcessImpersonated(
-		System::String^					commandLine,
-		System::String^					currentDirectory,
-		System::Boolean					waitForExit,
-		System::Text::StringBuilder^	stdOutput,
-		UserContext^					context
+		System::String^ commandLine,
+		System::String^ currentDirectory,
+		System::Boolean waitForExit,
+		System::Text::StringBuilder^ stdOutput,
+		UserContext^ context
 		);
 
 	static System::Boolean
 	SetDriverTraceEnabled(
-		System::UInt32		channels
+		System::UInt32 channels
 		);
 
 	static System::Boolean
 	SetDriverFlag(
-		System::String^		flagName,
-		System::UInt32		flagValue
+		System::String^ flagName,
+		System::UInt32 flagValue
 		);
 
 	static System::Boolean
 	GetDriverIsConnected(
-		System::Boolean%	connected
+		[System::Runtime::InteropServices::Out] System::Boolean% connected
 		);
 
 	static System::Boolean
 	GetDriverVersion(
-		System::UInt16%		major,
-		System::UInt16%		minor,
-		System::UInt16%		build,
-		System::UInt16%		revision
+		[System::Runtime::InteropServices::Out] System::UInt16% major,
+		[System::Runtime::InteropServices::Out] System::UInt16% minor,
+		[System::Runtime::InteropServices::Out] System::UInt16% build,
+		[System::Runtime::InteropServices::Out] System::UInt16% revision
 		);
 
 	static System::Boolean
 	SetupInstallHinfSection(
-		System::String^		sectionName,
-		System::String^		filePath
+		System::String^ sectionName,
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	IsFileExists(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	IsFileRegular(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	IsFileSymlink(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	IsFileDirectory(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	IsFileReadOnly(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	SetFileReadOnly(
-		System::String^		filePath,
-		System::Boolean		readOnly
+		System::String^ filePath,
+		System::Boolean readOnly
 		);
 
 	static System::IO::FileAttributes
 	GetFileAttributes(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Int64
 	GetFileSize(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Int64
 	GetFileUncompressedSize(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Int64
 	GetFileDiskSize(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::String^
 	GetFileSymlinkTarget(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::Boolean
 	IsFileExtendedPath(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static System::String^
 	GetFileExtendedPath(
-		System::String^		filePath
+		System::String^ filePath
 		);
 	
 	static System::String^
 	GetFileUnextendedPath(
-		System::String^		filePath
+		System::String^ filePath
 		);
 
 	static UserContext^

--- a/source/P4VFS.CoreInterop/Include/DepotSyncActionInterop.h
+++ b/source/P4VFS.CoreInterop/Include/DepotSyncActionInterop.h
@@ -17,6 +17,7 @@ public enum class DepotSyncFlags : System::Int32
 	IgnoreOutput	= P4::DepotSyncFlags::IgnoreOutput,
 	Quiet			= P4::DepotSyncFlags::Quiet,
 	Writeable		= P4::DepotSyncFlags::Writeable,
+	ClientSize		= P4::DepotSyncFlags::ClientSize,
 };
 
 public enum class DepotFlushType : System::Int32

--- a/source/P4VFS.CoreInterop/Include/DepotSyncActionInterop.h
+++ b/source/P4VFS.CoreInterop/Include/DepotSyncActionInterop.h
@@ -8,15 +8,15 @@ namespace P4VFS {
 namespace CoreInterop {
 
 [System::FlagsAttribute]
-public enum class DepotSyncType : System::Int32
+public enum class DepotSyncFlags : System::Int32
 {
-	Normal			= P4::DepotSyncType::Normal,
-	Force			= P4::DepotSyncType::Force,
-	Flush			= P4::DepotSyncType::Flush,
-	Preview			= P4::DepotSyncType::Preview,
-	IgnoreOutput	= P4::DepotSyncType::IgnoreOutput,
-	Quiet			= P4::DepotSyncType::Quiet,
-	Writeable		= P4::DepotSyncType::Writeable,
+	Normal			= P4::DepotSyncFlags::Normal,
+	Force			= P4::DepotSyncFlags::Force,
+	Flush			= P4::DepotSyncFlags::Flush,
+	Preview			= P4::DepotSyncFlags::Preview,
+	IgnoreOutput	= P4::DepotSyncFlags::IgnoreOutput,
+	Quiet			= P4::DepotSyncFlags::Quiet,
+	Writeable		= P4::DepotSyncFlags::Writeable,
 };
 
 public enum class DepotFlushType : System::Int32

--- a/source/P4VFS.CoreInterop/Include/DepotSyncOptionsInterop.h
+++ b/source/P4VFS.CoreInterop/Include/DepotSyncOptionsInterop.h
@@ -24,7 +24,7 @@ public:
 
 	array<System::String^>^ Files;
 	System::String^ Revision;
-	DepotSyncType SyncType;
+	DepotSyncFlags SyncFlags;
 	DepotFlushType FlushType;
 	DepotSyncMethod SyncMethod;
 	System::String^ SyncResident;

--- a/source/P4VFS.CoreInterop/Source/CoreInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/CoreInterop.cpp
@@ -147,7 +147,7 @@ LogSystem::Shutdown(
 
 FilePopulateInfo^
 NativeMethods::GetFilePopulateInfo(
-	System::String^		path
+	System::String^ path
 	)
 {
 	FileCore::GAllocPtr<P4VFS_REPARSE_DATA_2> populateData;
@@ -170,18 +170,18 @@ NativeMethods::GetFilePopulateInfo(
 
 System::Int32 
 NativeMethods::InstallReparsePointOnFile(
-		System::UInt16		majorVersion,
-		System::UInt16		minorVersion,
-		System::UInt16		buildVersion,
-		System::String^		filePath,
-		System::Byte		residencyPolicy,
-		System::UInt32		fileRevision,
-		System::Int64		fileSize,
-		System::UInt32		fileAttributes,
-		System::String^		depotPath,
-		System::String^		depotServer,
-		System::String^		depotClient,
-		System::String^		depotUser
+		System::UInt16 majorVersion,
+		System::UInt16 minorVersion,
+		System::UInt16 buildVersion,
+		System::String^ filePath,
+		System::Byte residencyPolicy,
+		System::UInt32 fileRevision,
+		System::Int64 fileSize,
+		System::UInt32 fileAttributes,
+		System::String^ depotPath,
+		System::String^ depotServer,
+		System::String^ depotClient,
+		System::String^ depotUser
 		)
 {
 	return FileOperations::InstallReparsePointOnFile(
@@ -202,8 +202,8 @@ NativeMethods::InstallReparsePointOnFile(
 
 System::Int32
 NativeMethods::CreateSymlinkFile(
-	System::String^		symlinkFilePath,
-	System::String^		targetFilePath
+	System::String^ symlinkFilePath,
+	System::String^ targetFilePath
 )
 {
 	return FileOperations::CreateSymlinkFile(
@@ -214,7 +214,7 @@ NativeMethods::CreateSymlinkFile(
 
 System::Int32 
 NativeMethods::RemoveReparsePoint(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileOperations::RemoveReparsePoint(marshal_as_wstring_c_str(filePath));
@@ -222,9 +222,9 @@ NativeMethods::RemoveReparsePoint(
 
 System::Int32 
 NativeMethods::PopulateFile(
-	System::String^		dstFile,
-	System::String^		srcFile,
-	FilePopulateMethod	populateMethod
+	System::String^ dstFile,
+	System::String^ srcFile,
+	FilePopulateMethod populateMethod
 	)
 {
 	return FileOperations::PopulateFile(marshal_as_wstring_c_str(dstFile), marshal_as_wstring_c_str(srcFile), safe_cast<BYTE>(populateMethod));
@@ -232,7 +232,7 @@ NativeMethods::PopulateFile(
 
 System::Int32 
 NativeMethods::HydrateFile(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileOperations::HydrateFile(marshal_as_wstring_c_str(filePath));
@@ -240,9 +240,9 @@ NativeMethods::HydrateFile(
 
 System::Boolean
 NativeMethods::ImpersonateFileAppend(
-	System::String^		filePath,
-	System::String^		text,
-	UserContext^		context
+	System::String^ filePath,
+	System::String^ text,
+	UserContext^ context
 	)
 {
 	return SUCCEEDED(FileOperations::ImpersonateFileAppend(
@@ -254,7 +254,7 @@ NativeMethods::ImpersonateFileAppend(
 
 System::Boolean
 NativeMethods::ImpersonateLoggedOnUser(
-	UserContext^		context
+	UserContext^ context
 	)
 {
 	return SUCCEEDED(FileOperations::ImpersonateLoggedOnUser(marshal_as_user_context(context)));
@@ -269,7 +269,7 @@ NativeMethods::RevertToSelf(
 
 System::String^
 NativeMethods::GetImpersonatedUserName(
-	UserContext^		context
+	UserContext^ context
 	)
 {
 	FileCore::String userName = FileOperations::GetImpersonatedUserName(marshal_as_user_context(context));
@@ -282,8 +282,8 @@ NativeMethods::GetImpersonatedUserName(
 
 System::String^
 NativeMethods::GetImpersonatedEnvironmentStrings(
-	System::String^		srcText,
-	UserContext^		context
+	System::String^ srcText,
+	UserContext^ context
 	)
 {
 	wchar_t dstText[2048] = {0};
@@ -298,12 +298,14 @@ NativeMethods::GetImpersonatedEnvironmentStrings(
 
 System::IntPtr^
 NativeMethods::GetLoggedOnUserToken(
-	UserContext^	context
+	UserContext^ context
 	)
 {
 	HANDLE hToken = FileOperations::GetLoggedOnUserToken(marshal_as_user_context(context));
 	if (hToken == INVALID_HANDLE_VALUE)
+	{
 		return System::IntPtr::Zero;
+	}
 	return gcnew System::IntPtr(hToken);
 }
 
@@ -313,17 +315,19 @@ NativeMethods::GetPreferredLoggedOnUserToken(
 {
 	HANDLE hToken = FileOperations::GetPreferredLoggedOnUserToken();
 	if (hToken == INVALID_HANDLE_VALUE)
+	{
 		return System::IntPtr::Zero;
+	}
 	return gcnew System::IntPtr(hToken);
 }
 
 System::Boolean
 NativeMethods::CreateProcessImpersonated(
-	System::String^					commandLine,
-	System::String^					currentDirectory,
-	System::Boolean					waitForExit,
-	System::Text::StringBuilder^	stdOutput,
-	UserContext^					context
+	System::String^ commandLine,
+	System::String^ currentDirectory,
+	System::Boolean waitForExit,
+	System::Text::StringBuilder^ stdOutput,
+	UserContext^ context
 	)
 {
 	FileCore::String stdOutputResult;
@@ -343,7 +347,7 @@ NativeMethods::CreateProcessImpersonated(
 
 System::Boolean
 NativeMethods::SetDriverTraceEnabled(
-	System::UInt32		channels
+	System::UInt32 channels
 	)
 {
 	return SUCCEEDED(FileOperations::SetDriverTraceEnabled(channels));
@@ -351,8 +355,8 @@ NativeMethods::SetDriverTraceEnabled(
 
 System::Boolean
 NativeMethods::SetDriverFlag(
-	System::String^		flagName,
-	System::UInt32		flagValue
+	System::String^ flagName,
+	System::UInt32 flagValue
 	)
 {
 	return SUCCEEDED(FileOperations::SetDriverFlag(marshal_as_wstring_c_str(flagName), flagValue));
@@ -360,27 +364,31 @@ NativeMethods::SetDriverFlag(
 
 System::Boolean
 NativeMethods::GetDriverIsConnected(
-	System::Boolean%	connected
+	[System::Runtime::InteropServices::Out] System::Boolean% connected
 	)
 {
 	bool driverConnected = false;
 	if (SUCCEEDED(FileOperations::GetDriverIsConnected(driverConnected)) == false)
+	{
 		return false;
+	}
 	connected = driverConnected;
 	return true;
 }
 
 System::Boolean
 NativeMethods::GetDriverVersion(
-	System::UInt16%		major,
-	System::UInt16%		minor,
-	System::UInt16%		build,
-	System::UInt16%		revision
+	[System::Runtime::InteropServices::Out] System::UInt16% major,
+	[System::Runtime::InteropServices::Out] System::UInt16% minor,
+	[System::Runtime::InteropServices::Out] System::UInt16% build,
+	[System::Runtime::InteropServices::Out] System::UInt16% revision
 	)
 {
 	USHORT driverMajor(0), driverMinor(0), driverBuild(0), driverRevision(0);
 	if (SUCCEEDED(FileOperations::GetDriverVersion(driverMajor, driverMinor, driverBuild, driverRevision)) == false)
+	{
 		return false;
+	}
 	major = driverMajor;
 	minor = driverMinor;
 	build = driverBuild;
@@ -390,8 +398,8 @@ NativeMethods::GetDriverVersion(
 
 System::Boolean
 NativeMethods::SetupInstallHinfSection(
-	System::String^		sectionName,
-	System::String^		filePath
+	System::String^ sectionName,
+	System::String^ filePath
 	)
 {
 	return SUCCEEDED(FileSystem::SetupInstallHinfSection(marshal_as_wstring_c_str(sectionName), marshal_as_wstring_c_str(filePath)));
@@ -399,7 +407,7 @@ NativeMethods::SetupInstallHinfSection(
 
 System::Boolean
 NativeMethods::IsFileExists(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::Exists(marshal_as_wstring_c_str(filePath));
@@ -407,7 +415,7 @@ NativeMethods::IsFileExists(
 
 System::Boolean
 NativeMethods::IsFileRegular(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::IsRegular(marshal_as_wstring_c_str(filePath));
@@ -415,7 +423,7 @@ NativeMethods::IsFileRegular(
 
 System::Boolean
 NativeMethods::IsFileSymlink(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::IsSymlink(marshal_as_wstring_c_str(filePath));
@@ -423,7 +431,7 @@ NativeMethods::IsFileSymlink(
 
 System::Boolean
 NativeMethods::IsFileDirectory(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::IsDirectory(marshal_as_wstring_c_str(filePath));
@@ -431,7 +439,7 @@ NativeMethods::IsFileDirectory(
 
 System::Boolean
 NativeMethods::IsFileReadOnly(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::IsReadOnly(marshal_as_wstring_c_str(filePath));
@@ -439,8 +447,8 @@ NativeMethods::IsFileReadOnly(
 
 System::Boolean
 NativeMethods::SetFileReadOnly(
-	System::String^		filePath,
-	System::Boolean		readOnly
+	System::String^ filePath,
+	System::Boolean readOnly
 	)
 {
 	return FileCore::FileInfo::SetReadOnly(marshal_as_wstring_c_str(filePath), readOnly);
@@ -448,7 +456,7 @@ NativeMethods::SetFileReadOnly(
 
 System::IO::FileAttributes
 NativeMethods::GetFileAttributes(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	DWORD attributes = FileCore::FileInfo::FileAttributes(marshal_as_wstring_c_str(filePath));
@@ -461,7 +469,7 @@ NativeMethods::GetFileAttributes(
 
 System::Int64
 NativeMethods::GetFileSize(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::FileSize(marshal_as_wstring_c_str(filePath));
@@ -469,7 +477,7 @@ NativeMethods::GetFileSize(
 
 System::Int64
 NativeMethods::GetFileUncompressedSize(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::FileUncompressedSize(marshal_as_wstring_c_str(filePath));
@@ -477,7 +485,7 @@ NativeMethods::GetFileUncompressedSize(
 
 System::Int64
 NativeMethods::GetFileDiskSize(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::FileDiskSize(marshal_as_wstring_c_str(filePath));
@@ -485,7 +493,7 @@ NativeMethods::GetFileDiskSize(
 
 System::String^
 NativeMethods::GetFileSymlinkTarget(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return Marshal::FromNativeWide(FileCore::FileInfo::SymlinkTarget(marshal_as_wstring_c_str(filePath)).c_str());
@@ -493,7 +501,7 @@ NativeMethods::GetFileSymlinkTarget(
 
 System::Boolean
 NativeMethods::IsFileExtendedPath(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return FileCore::FileInfo::IsExtendedPath(marshal_as_wstring_c_str(filePath));
@@ -501,7 +509,7 @@ NativeMethods::IsFileExtendedPath(
 
 System::String^
 NativeMethods::GetFileExtendedPath(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return Marshal::FromNativeWide(FileCore::FileInfo::ExtendedPath(marshal_as_wstring_c_str(filePath)).c_str());
@@ -509,7 +517,7 @@ NativeMethods::GetFileExtendedPath(
 
 System::String^
 NativeMethods::GetFileUnextendedPath(
-	System::String^		filePath
+	System::String^ filePath
 	)
 {
 	return Marshal::FromNativeWide(FileCore::FileInfo::UnextendedPath(marshal_as_wstring_c_str(filePath)).c_str());

--- a/source/P4VFS.CoreInterop/Source/DepotSyncOptionsInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DepotSyncOptionsInterop.cpp
@@ -11,7 +11,7 @@ namespace CoreInterop {
 DepotSyncOptions::DepotSyncOptions() :
 	Files(nullptr),
 	Revision(nullptr),
-	SyncType(DepotSyncType::Normal),
+	SyncFlags(DepotSyncFlags::Normal),
 	SyncMethod(DepotSyncMethod::Virtual),
 	FlushType(DepotFlushType::Atomic),
 	Context(nullptr)
@@ -22,7 +22,7 @@ P4::FDepotSyncOptions DepotSyncOptions::ToNative()
 {
 	P4::FDepotSyncOptions dst;
 	dst.m_Revision = P4::FDepotRevision::FromString(marshal_as_astring(Revision));
-	dst.m_SyncType = safe_cast<P4::DepotSyncType::Enum>(SyncType);
+	dst.m_SyncFlags = safe_cast<P4::DepotSyncFlags::Enum>(SyncFlags);
 	dst.m_FlushType = safe_cast<P4::DepotFlushType::Enum>(FlushType);
 	dst.m_SyncMethod = safe_cast<P4::DepotSyncMethod::Enum>(SyncMethod);
 	dst.m_SyncResident = marshal_as_astring(SyncResident);

--- a/source/P4VFS.CoreInterop/Tests/TestFactoryInterop.cpp
+++ b/source/P4VFS.CoreInterop/Tests/TestFactoryInterop.cpp
@@ -64,7 +64,7 @@ TestFactoryInterop::Run(
 	}
 	catch (std::exception e)
 	{
-		throw gcnew System::Exception(Marshal::FromNativeAnsi(e.what()));
+		throw gcnew System::Exception(Marshal::FromNativeAnsi(e.what())->Trim());
 	}
 	catch (...)
 	{

--- a/source/P4VFS.Driver/Include/DriverCore.h
+++ b/source/P4VFS.Driver/Include/DriverCore.h
@@ -129,3 +129,7 @@ P4vfsCloseReparsePoint(
 	_In_ PFILE_OBJECT pFileObject
 	);
 
+BOOLEAN
+P4vfsIsCurrentProcessElevated(
+	);
+

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -4,8 +4,8 @@
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					26			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
-#define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
+#define P4VFS_VER_BUILD					2			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_REVISION				1			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v
 #define P4VFS_VER_STRINGIZE(v)			P4VFS_VER_STRINGIZE_EX(v)

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -5,7 +5,7 @@
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					26			// Increment this number whenever the driver changes
 #define P4VFS_VER_BUILD					2			// Increment this number when a major user mode change has been made
-#define P4VFS_VER_REVISION				1			// Increment this number when we rebuild with any change
+#define P4VFS_VER_REVISION				2			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v
 #define P4VFS_VER_STRINGIZE(v)			P4VFS_VER_STRINGIZE_EX(v)

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
-#define P4VFS_VER_MINOR					26			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					2			// Increment this number when a major user mode change has been made
-#define P4VFS_VER_REVISION				3			// Increment this number when we rebuild with any change
+#define P4VFS_VER_MINOR					27			// Increment this number whenever the driver changes
+#define P4VFS_VER_BUILD					0			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v
 #define P4VFS_VER_STRINGIZE(v)			P4VFS_VER_STRINGIZE_EX(v)

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -5,7 +5,7 @@
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					26			// Increment this number whenever the driver changes
 #define P4VFS_VER_BUILD					2			// Increment this number when a major user mode change has been made
-#define P4VFS_VER_REVISION				2			// Increment this number when we rebuild with any change
+#define P4VFS_VER_REVISION				3			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v
 #define P4VFS_VER_STRINGIZE(v)			P4VFS_VER_STRINGIZE_EX(v)

--- a/source/P4VFS.Driver/Scripts/TestInstall.bat
+++ b/source/P4VFS.Driver/Scripts/TestInstall.bat
@@ -22,12 +22,12 @@ EXIT /B 1
 :WIN_SDK_X64_DIR_EXISTS
 
 :: Import test sign certificate to local store
-"%WIN_SDK_X64_DIR%\certmgr.exe" -add "%DRIVER_INF_FOLDER%\P4VFS.Driver.WDKTest.pfx" -all -s -r LocalMachine ROOT
+"%WIN_SDK_X64_DIR%\certmgr.exe" -add "%DRIVER_INF_FOLDER%\p4vfsflt.cer" -all -s -r LocalMachine ROOT
 IF NOT "%ERRORLEVEL%"=="0" (
 	ECHO Failed to add test certificate to LocalMachine Root
 	EXIT /B 1
 )
-"%WIN_SDK_X64_DIR%\certmgr.exe" -add "%DRIVER_INF_FOLDER%\P4VFS.Driver.WDKTest.pfx" -all -s -r LocalMachine TRUSTEDPUBLISHER
+"%WIN_SDK_X64_DIR%\certmgr.exe" -add "%DRIVER_INF_FOLDER%\p4vfsflt.cer" -all -s -r LocalMachine TRUSTEDPUBLISHER
 IF NOT "%ERRORLEVEL%"=="0" (
 	ECHO Failed to add test certificate to LocalMachine Trusted Publisher
 	EXIT /B 1

--- a/source/P4VFS.Driver/Source/DriverFilter.c
+++ b/source/P4VFS.Driver/Source/DriverFilter.c
@@ -931,7 +931,8 @@ P4vfsPostCreate(
 	// Determine if we our hitting our reparse point and should hydrate
 	if (pData->IoStatus.Status == STATUS_REPARSE &&
 		pData->TagData->FileTag == P4VFS_REPARSE_TAG &&
-		FlagOn(pData->Iopb->Parameters.Create.Options, FILE_OPEN_REPARSE_POINT) == 0)
+		FlagOn(pData->Iopb->Parameters.Create.Options, FILE_OPEN_REPARSE_POINT) == 0 &&
+		P4vfsIsReparseGuid(&pData->TagData->GenericGUIDReparseBuffer.TagGuid))
 	{
 		// Since this is our reparse determine if all the 
 		// other conditions are met to make the file resident

--- a/source/P4VFS.Driver/Source/DriverFilter.c
+++ b/source/P4VFS.Driver/Source/DriverFilter.c
@@ -771,6 +771,13 @@ P4vfsControlPortMessage(
 		}
 		case P4VFS_OPERATION_SET_FLAG:
 		{
+			if (P4vfsIsCurrentProcessElevated() == FALSE)
+			{
+				P4vfsTraceError(Filter, L"P4vfsControlPortMessage: P4VFS_CONTROL_SET_FLAG elevation required");
+				status = STATUS_ELEVATION_REQUIRED;
+				break;
+			}
+
 			const WCHAR strSanitizeAttributes[] = L"SanitizeAttributes";
 			if (RtlCompareMemory(strSanitizeAttributes, input->data.SET_FLAG.name, sizeof(strSanitizeAttributes)) == sizeof(strSanitizeAttributes))
 			{

--- a/source/P4VFS.Extensions/P4VFS.Extensions.csproj
+++ b/source/P4VFS.Extensions/P4VFS.Extensions.csproj
@@ -129,7 +129,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/P4VFS.Extensions/Source/Common/SocketModel.cs
+++ b/source/P4VFS.Extensions/Source/Common/SocketModel.cs
@@ -180,7 +180,7 @@ namespace Microsoft.P4VFS.Extensions.SocketModel
 			using (var impersonate = new Impersonation.ImpersonateLoggedOnUserScope(request.SyncOptions.Context))
 			{
 				LogDevice log = new SocketModelLogDevice(stream, _Cancellation.Token);
-				if (request.SyncOptions.SyncType.HasFlag(DepotSyncType.Quiet) == false)
+				if (request.SyncOptions.SyncFlags.HasFlag(DepotSyncFlags.Quiet) == false)
 				{
 					LogDeviceAggregate aggregateLog = new LogDeviceAggregate();
 					aggregateLog.Devices.Add(log);

--- a/source/P4VFS.Extensions/Source/Common/VirtualFileSystem.cs
+++ b/source/P4VFS.Extensions/Source/Common/VirtualFileSystem.cs
@@ -50,8 +50,7 @@ namespace Microsoft.P4VFS.Extensions
 
 		public static bool IsDriverReady()
 		{
-			bool isConnected = false;
-			if (NativeMethods.GetDriverIsConnected(ref isConnected) == false || isConnected == false)
+			if (NativeMethods.GetDriverIsConnected(out bool isConnected) == false || isConnected == false)
 			{
 				return false;
 			}
@@ -266,11 +265,7 @@ namespace Microsoft.P4VFS.Extensions
 
 		public static VersionDescriptor GetDriverVersion()
 		{
-			ushort major = 0;
-			ushort minor = 0;
-			ushort build = 0;
-			ushort revision = 0;
-			NativeMethods.GetDriverVersion(ref major, ref minor, ref build, ref revision);
+			NativeMethods.GetDriverVersion(out ushort major, out ushort minor, out ushort build, out ushort revision);
 			return new VersionDescriptor(major, minor, build, revision);
 		}
 

--- a/source/P4VFS.Extensions/Source/Depot/DepotClientExtensions.cs
+++ b/source/P4VFS.Extensions/Source/Depot/DepotClientExtensions.cs
@@ -26,17 +26,17 @@ namespace Microsoft.P4VFS.Extensions
 			return depotClient.Run(command).ToView<DepotResultViewType>();
 		}
 
-		public static DepotSyncResult Sync(this DepotClient depotClient, string files, DepotRevision revision = null, DepotSyncType syncType = DepotSyncType.Normal, DepotSyncMethod syncMethod = DepotSyncMethod.Virtual, DepotFlushType flushType = DepotFlushType.Atomic, string syncResident = null)
+		public static DepotSyncResult Sync(this DepotClient depotClient, string files, DepotRevision revision = null, DepotSyncFlags syncFlags = DepotSyncFlags.Normal, DepotSyncMethod syncMethod = DepotSyncMethod.Virtual, DepotFlushType flushType = DepotFlushType.Atomic, string syncResident = null)
 		{
-			return depotClient.Sync(new string[]{ files }, revision, syncType, syncMethod, flushType, syncResident);
+			return depotClient.Sync(new string[]{ files }, revision, syncFlags, syncMethod, flushType, syncResident);
 		}
 
-		public static DepotSyncResult Sync(this DepotClient depotClient, IEnumerable<string> files, DepotRevision revision = null, DepotSyncType syncType = DepotSyncType.Normal, DepotSyncMethod syncMethod = DepotSyncMethod.Virtual, DepotFlushType flushType = DepotFlushType.Atomic, string syncResident = null)
+		public static DepotSyncResult Sync(this DepotClient depotClient, IEnumerable<string> files, DepotRevision revision = null, DepotSyncFlags syncFlags = DepotSyncFlags.Normal, DepotSyncMethod syncMethod = DepotSyncMethod.Virtual, DepotFlushType flushType = DepotFlushType.Atomic, string syncResident = null)
 		{
 			DepotSyncOptions syncOptions = new DepotSyncOptions();
 			syncOptions.Files = files?.ToArray();
 			syncOptions.Revision = revision?.ToString();
-			syncOptions.SyncType = syncType;
+			syncOptions.SyncFlags = syncFlags;
 			syncOptions.SyncMethod = syncMethod;
 			syncOptions.SyncResident = syncResident;
 			syncOptions.FlushType = flushType;

--- a/source/P4VFS.Extensions/Source/Utilities/ProcessInfo.cs
+++ b/source/P4VFS.Extensions/Source/Utilities/ProcessInfo.cs
@@ -276,14 +276,14 @@ namespace Microsoft.P4VFS.Extensions.Utilities
 			bool copy = false,
 			bool interactive = false,
 			StringBuilder stdout = null,
-			string sysInternalsSuiteFolder = null)
+			string sysInternalsFolder = null)
 		{
-			if (String.IsNullOrEmpty(sysInternalsSuiteFolder))
+			if (String.IsNullOrEmpty(sysInternalsFolder))
 			{
-				sysInternalsSuiteFolder = String.Format("{0}\\SysinternalsSuite", Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
+				sysInternalsFolder = String.Format("{0}\\SysinternalsSuite", Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles));
 			}
 
-			string psExecExe = String.Format("{0}\\psexec.exe", sysInternalsSuiteFolder);
+			string psExecExe = String.Format("{0}\\psexec.exe", sysInternalsFolder);
 			string psExecArgs = String.Format("\\\\{0} -u {1} -p {2} -accepteula -nobanner", remoteHost, remoteUser, remotePasswd);
 			if (admin)
 			{

--- a/source/P4VFS.External/P4VFS.External.csproj
+++ b/source/P4VFS.External/P4VFS.External.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.6.1</Version>
+      <Version>6.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/P4VFS.External/Source/Module.cs
+++ b/source/P4VFS.External/Source/Module.cs
@@ -129,14 +129,14 @@ namespace Microsoft.P4VFS.External
 			Dictionary<string, string> checksums = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 			foreach (string line in File.ReadAllLines(checksumFilePath))
 			{
-				Match m = Regex.Match(line, @"^(?<sum>[0-9a-f]+)\s+\*(?<name>\S+)\s*$", RegexOptions.IgnoreCase);
+				Match m = Regex.Match(line, @"^\s*(?<sum>[0-9a-f]+)\s+\*(?<name>\S+)\s*$", RegexOptions.IgnoreCase);
 				if (m.Success)
 				{
 					checksums[m.Groups["name"].Value] = m.Groups["sum"].Value;
 					continue;
 				}
 
-				m = Regex.Match(line, @"^(?<sum>[0-9a-f]+)\s*$", RegexOptions.IgnoreCase);
+				m = Regex.Match(line, @"^\s*(?<sum>[0-9a-f]+)\s*$", RegexOptions.IgnoreCase);
 				if (m.Success)
 				{
 					checksums[Path.GetFileNameWithoutExtension(checksumFilePath)] = m.Groups["sum"].Value;

--- a/source/P4VFS.Setup/P4VFS.Setup.csproj
+++ b/source/P4VFS.Setup/P4VFS.Setup.csproj
@@ -205,7 +205,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Target Name="CopyStagingResources">

--- a/source/P4VFS.Setup/Source/SetupWindow.xaml.cs
+++ b/source/P4VFS.Setup/Source/SetupWindow.xaml.cs
@@ -33,6 +33,7 @@ namespace Microsoft.P4VFS.Setup
 			_ProgressLayers.Add(new ProgressLayer{ CurrentStep = 0, TotalSteps = 1 });
 			_DescriptionText = String.Format("Microsoft P4VFS {0}", Microsoft.P4VFS.CoreInterop.NativeConstants.Version);
 			_StatusText = "";
+			_Text.Clear();
 			_UpdateTimer = new DispatcherTimer();
 			_UpdateTimer.Interval = TimeSpan.FromSeconds(1.0/30.0);
 			_UpdateTimer.Tick += OnTickUpdateTimer;

--- a/source/P4VFS.UnitTest/P4VFS.UnitTest.csproj
+++ b/source/P4VFS.UnitTest/P4VFS.UnitTest.csproj
@@ -148,7 +148,7 @@
       <Version>2.0.1406.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />

--- a/source/P4VFS.UnitTest/Scripts/RestartPerforceServer.bat
+++ b/source/P4VFS.UnitTest/Scripts/RestartPerforceServer.bat
@@ -10,30 +10,37 @@ IF NOT "%1"=="/admin" (
 	GOTO :EOF
 )
 
-PUSHD "%SCRIPT_FOLDER%\..\..\..\intermediate\1666"
-SET SERVER_FOLDER=%CD%
+PUSHD "%SCRIPT_FOLDER%\..\..\.."
+SET REPO_FOLDER=%CD%
 POPD
 
+SET SERVER_FOLDER=%REPO_FOLDER%\intermediate\1666
+SET P4D_EXE=%SERVER_FOLDER%\p4d.exe
+SET P4_EXE=p4.exe
+FOR /F "tokens=*" %%A IN ('dir /s /b "%REPO_FOLDER%\external\P4API\p4.exe"') DO (
+	SET P4_EXE=%%A
+)
+
 taskkill.exe /F /IM p4d.exe > nul 2>&1
-START cmd.exe /c ""%SERVER_FOLDER%\p4d.exe" -L "%SERVER_FOLDER%\p4d.log" -r "%SERVER_FOLDER%\db" -p 1666 -Id P4VFS_TEST -J off"
+START cmd.exe /s /c ""%P4D_EXE%" -L "%SERVER_FOLDER%\p4d.log" -r "%SERVER_FOLDER%\db" -p 1666 -Id P4VFS_TEST -J off"
 
 :P4D_WAIT
 SET P4_ARGS=-p localhost:1666
-p4.exe %P4_ARGS% info > nul
+"%P4_EXE%" %P4_ARGS% info > nul
 IF "%ERRORLEVEL%"=="0" GOTO :P4D_READY
 ECHO waiting for p4d ...
-sleep 2
+timeout /nobreak /t 2 > nul
 GOTO :P4D_WAIT
 
 :P4D_READY
 ECHO p4d ready
-ECHO Password1| p4.exe %P4_ARGS% -u p4vfstest login
+ECHO Password1| "%P4_EXE%" %P4_ARGS% -u p4vfstest login
 IF NOT "%ERRORLEVEL%"=="0" GOTO :P4D_FAILED
-p4.exe %P4_ARGS% -u p4vfstest login northamerica\gatineau
+"%P4_EXE%" %P4_ARGS% -u p4vfstest login northamerica\gatineau
 IF NOT "%ERRORLEVEL%"=="0" GOTO :P4D_FAILED
-p4.exe %P4_ARGS% -u p4vfstest login northamerica\quebec
+"%P4_EXE%" %P4_ARGS% -u p4vfstest login northamerica\quebec
 IF NOT "%ERRORLEVEL%"=="0" GOTO :P4D_FAILED
-p4.exe %P4_ARGS% -u p4vfstest login northamerica\montreal
+"%P4_EXE%" %P4_ARGS% -u p4vfstest login northamerica\montreal
 IF NOT "%ERRORLEVEL%"=="0" GOTO :P4D_FAILED
 ECHO p4d startup success
 GOTO :EOF

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -194,14 +194,26 @@ namespace Microsoft.P4VFS.UnitTest
 
 		public static void AssertLambda(Func<bool> expression, string message = "")
 		{
-			try { Assert(expression(), message); } 
-			catch { Assert(false, message); }
+			try 
+			{ 
+				Assert(expression(), message); 
+			} 
+			catch (Exception e)
+			{ 
+				Assert(false, String.Join("\n", message, e.ToString()).Trim()); 
+			}
 		}
 
 		public static void AssertLambda(Action expression, string message = "")
 		{
-			try { expression(); } 
-			catch { Assert(false, message); }
+			try 
+			{ 
+				expression(); 
+			} 
+			catch (Exception e)
+			{ 
+				Assert(false, String.Join("\n", message, e.ToString()).Trim()); 
+			}
 		}
 
 		public static string GetCachedFilePath(ref string filePath, Func<string> getFilePath)

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -24,6 +24,31 @@ namespace Microsoft.P4VFS.UnitTest
 		{
 			try
 			{
+				int argIndex = 0;
+				for (; argIndex < args.Length; ++argIndex)
+				{
+					if (String.Compare(args[argIndex], "-r") == 0)
+					{
+						IsTestRemote = true;
+					}
+					else if (String.Compare(args[argIndex], "-e") == 0)
+					{
+						IsTestAllowUnelevated = true;
+					}
+					else
+					{
+						break;
+					}
+				}
+
+				args = args.Skip(argIndex).ToArray();
+				
+				if (IsTestAllowUnelevated == false && ShellUtilities.IsProcessElevated() == false)
+				{
+					VirtualFileSystemLog.Error("Unable to run tests as non-elevated process");
+					return false;
+				}
+
 				if (config != null)
 				{
 					if (String.IsNullOrWhiteSpace(config.Port) == false)
@@ -46,21 +71,6 @@ namespace Microsoft.P4VFS.UnitTest
 						Environment.SetEnvironmentVariable("P4PASSWD", config.Passwd);
 					}
 				}
-
-				int argIndex = 0;
-				for (; argIndex < args.Length; ++argIndex)
-				{
-					if (String.Compare(args[argIndex], "-r") == 0)
-					{
-						IsTestRemote = true;
-					}
-					else
-					{
-						break;
-					}
-				}
-
-				args = args.Skip(argIndex).ToArray();
 
 				Assembly unitTestAssembly = Assembly.GetExecutingAssembly();
 				List<TestMethodInfo> testMethods = new List<TestMethodInfo>();
@@ -346,6 +356,12 @@ namespace Microsoft.P4VFS.UnitTest
 		}
 
 		public static bool IsTestRemote
+		{
+			get;
+			private set;
+		}
+
+		public static bool IsTestAllowUnelevated
 		{
 			get;
 			private set;

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -280,12 +280,12 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(String.IsNullOrEmpty(root) == false);
 				Assert(depotClient.Opened().Count == 0 || depotClient.Run("revert", new[]{ "-k", "//..." }).HasError == false);
 
-				depotClient.Sync("//...", new DepotRevisionNone(), DepotSyncType.Force|DepotSyncType.Quiet, DepotSyncMethod.Regular);
+				depotClient.Sync("//...", new DepotRevisionNone(), DepotSyncFlags.Force|DepotSyncFlags.Quiet, DepotSyncMethod.Regular);
 				AssertLambda(() => FileUtilities.DeleteDirectoryAndFiles(root));
 				AssertRetry(() => Directory.Exists(root) == false, String.Format("directory exists {0}", root));
 				if (depotClient.GetHeadRevisionChangelist() != null)
 				{
-					DepotSyncResult syncResult = depotClient.Sync("//...#none", null, DepotSyncType.Normal);
+					DepotSyncResult syncResult = depotClient.Sync("//...#none", null, DepotSyncFlags.Normal);
 					Assert(syncResult?.Modifications != null);
 					Assert(syncResult.Modifications.Where(a => !FDepotSyncActionType.IsError(a.SyncActionType)).Any() == false);
 				}
@@ -629,9 +629,9 @@ namespace Microsoft.P4VFS.UnitTest
 		{
 			foreach (ServiceSettingsScope item in EnumerateCommonServicePopulateSettings(false))
 			{
-				foreach (DepotSyncType primarySyncType in new[]{ DepotSyncType.Normal, DepotSyncType.Quiet, DepotSyncType.IgnoreOutput })
+				foreach (DepotSyncFlags primarySyncFlags in new[]{ DepotSyncFlags.Normal, DepotSyncFlags.Quiet, DepotSyncFlags.IgnoreOutput })
 				{
-					item.SyncType = primarySyncType;
+					item.SyncFlags = primarySyncFlags;
 					if (verbose)
 						VirtualFileSystemLog.Info("EnumerateCommonServiceSyncSettings: {0}", item);
 					yield return item;
@@ -844,7 +844,7 @@ namespace Microsoft.P4VFS.UnitTest
 	public class ServiceSettingsScope : IDisposable
 	{
 		public List<ServiceSettingScope> ServiceSettings = new List<ServiceSettingScope>();
-		public DepotSyncType? SyncType;
+		public DepotSyncFlags? SyncFlags;
 		public string LineEnd;
 
 		public void Dispose()
@@ -856,8 +856,8 @@ namespace Microsoft.P4VFS.UnitTest
 		public override string ToString()
 		{
 			string result = String.Format("ServiceSettings=[{0}]", String.Join(",", ServiceSettings));
-			if (SyncType.HasValue)
-				result += String.Format(", SyncType=[{0}]", SyncType.Value);
+			if (SyncFlags.HasValue)
+				result += String.Format(", SyncFlags=[{0}]", SyncFlags.Value);
 			if (LineEnd != null)
 				result += String.Format(", LineEnd={0}", LineEnd);
 			return result;

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -640,6 +640,16 @@ namespace Microsoft.P4VFS.UnitTest
 			return summary;
 		}
 
+		public IEnumerable<DepotSyncFlags> EnumerateCommonPrimaryDepotSyncFlags(bool verbose = true)
+		{
+			foreach (DepotSyncFlags primarySyncFlags in new[]{ DepotSyncFlags.Normal, DepotSyncFlags.Quiet, DepotSyncFlags.IgnoreOutput })
+			{
+				if (verbose)
+					VirtualFileSystemLog.Info("EnumerateCommonPrimaryDepotSyncFlags: {0}", primarySyncFlags);
+				yield return primarySyncFlags;
+			}
+		}
+
 		public IEnumerable<ServiceSettingsScope> EnumerateCommonServicePopulateSettings(bool verbose = true)
 		{
 			foreach (FilePopulateMethod populateMethod in new[]{ FilePopulateMethod.Copy, FilePopulateMethod.Stream })
@@ -656,7 +666,7 @@ namespace Microsoft.P4VFS.UnitTest
 		{
 			foreach (ServiceSettingsScope item in EnumerateCommonServicePopulateSettings(false))
 			{
-				foreach (DepotSyncFlags primarySyncFlags in new[]{ DepotSyncFlags.Normal, DepotSyncFlags.Quiet, DepotSyncFlags.IgnoreOutput })
+				foreach (DepotSyncFlags primarySyncFlags in EnumerateCommonPrimaryDepotSyncFlags(false))
 				{
 					item.SyncFlags = primarySyncFlags;
 					if (verbose)
@@ -682,7 +692,7 @@ namespace Microsoft.P4VFS.UnitTest
 
 		public IEnumerable<string> EnumerateCommonConsoleSyncOptions(bool verbose = true)
 		{
-			foreach (string p0 in new[]{ "-s", "-t", "-q", "-l" })
+			foreach (string p0 in new[]{ "-s", "-t", "-q", "-l", "-c" })
 			{
 				foreach (string p1 in new[]{ "-m Single", "-m Atomic", "-r" })
 				{

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -24,12 +24,6 @@ namespace Microsoft.P4VFS.UnitTest
 		{
 			try
 			{
-				if (ShellUtilities.IsProcessElevated() == false)
-				{
-					VirtualFileSystemLog.Error("Unable to run tests as non-elevated process");
-					return false;
-				}
-
 				if (config != null)
 				{
 					if (String.IsNullOrWhiteSpace(config.Port) == false)
@@ -379,6 +373,11 @@ namespace Microsoft.P4VFS.UnitTest
 		public static string InstalledP4vfsExe
 		{
 			get { return GetCachedFilePath(ref _InstalledP4vfsExe, () => Path.GetFullPath(String.Format("{0}\\{1}", GetP4vfsInstallFolder(), Path.GetFileName(P4vfsExe)))); }
+		}
+
+		public static string SysInternalsFolder
+		{
+			get { return String.Format("{0}\\SysinternalsSuite", Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)); }
 		}
 
 		public static string GetRepositoryRootFolder()

--- a/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
@@ -25,15 +25,15 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
 				string clientRoot = GetClientRoot(depotClient);
 
-				DepotSyncResult syncResult = depotClient.Sync("//depot/gears1/Development/Src/Core/...", null, syncType, DepotSyncMethod.Virtual);
+				DepotSyncResult syncResult = depotClient.Sync("//depot/gears1/Development/Src/Core/...", null, syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 				long rootLocalSize = FileUtilities.GetDirectorySize(clientRoot);
 				Assert(rootLocalSize >= 0);
 				long rootDepotSize = depotClient.GetDepotSize(new[]{ "//depot/gears1/Development/Src/Core/..." });
@@ -52,9 +52,9 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(IsPlaceholderFile(coreFile) == false);
 
 				string canvasFile = String.Format(@"{0}\depot\gears1\Development\Src\Engine\Src\UnCanvas.cpp", clientRoot);
-				syncResult = depotClient.Sync(canvasFile, null, syncType, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync(canvasFile, null, syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 				Assert(IsPlaceholderFile(canvasFile));
 
 				Assert(depotClient.Run("edit", new[]{ canvasFile }).HasError == false);
@@ -63,23 +63,23 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(IsPlaceholderFile(canvasFile) == false);
 
 				Assert(depotClient.Run("revert", new[]{ canvasFile }).HasError == false);
-				syncResult = depotClient.Sync(canvasFile, new DepotRevisionNumber(1), syncType, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync(canvasFile, new DepotRevisionNumber(1), syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 				Assert(IsPlaceholderFile(canvasFile));
 				Assert(File.ReadAllLines(canvasFile).Length == 515);
 				Assert(IsPlaceholderFile(canvasFile) == false);
 
-				syncResult = depotClient.Sync(canvasFile + "#2", null, syncType, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync(canvasFile + "#2", null, syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 				Assert(IsPlaceholderFile(canvasFile));
 				Assert(File.ReadAllLines(canvasFile).Length == 521);
 				Assert(IsPlaceholderFile(canvasFile) == false);
 
-				syncResult = depotClient.Sync(canvasFile, new DepotRevisionNone(), syncType, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync(canvasFile, new DepotRevisionNone(), syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 				Assert(Directory.Exists(String.Format(@"{0}\depot\gears1\Development\Src\Engine", clientRoot)) == false);
 				Assert(Directory.Exists(String.Format(@"{0}\depot\gears1\Development\Src", clientRoot)) == true);
 			}}}
@@ -92,7 +92,7 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
@@ -100,22 +100,22 @@ namespace Microsoft.P4VFS.UnitTest
 				string clientRoot = GetClientRoot(depotClient);
 				string fileLocalPath = String.Format(@"{0}\depot\gears1\Development\Src\Core\Src\Core.cpp", clientRoot);
 
-				DepotSyncResult syncResult = depotClient.Sync(fileLocalPath, new DepotRevisionHead(), syncType, DepotSyncMethod.Regular);
+				DepotSyncResult syncResult = depotClient.Sync(fileLocalPath, new DepotRevisionHead(), syncFlags, DepotSyncMethod.Regular);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 1);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 1);
 				Assert(File.Exists(fileLocalPath), "File Path should not exist.");
 				Assert(IsPlaceholderFile(fileLocalPath) == false, "File Path should not be placeholder.");
 
 				// Delete the file that we're interested in
-				syncResult = depotClient.Sync(fileLocalPath, new DepotRevisionNone(), syncType, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync(fileLocalPath, new DepotRevisionNone(), syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 1);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 1);
 				Assert(File.Exists(fileLocalPath) == false, "File Path should not exist.");
 
 				// Now virtual sync to the head revision
-				syncResult = depotClient.Sync(fileLocalPath, new DepotRevisionHead(), syncType, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync(fileLocalPath, new DepotRevisionHead(), syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 1);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 1);
 				Assert(IsPlaceholderFile(fileLocalPath), "File Path should exist.");
 
 				// Now make the file resident and check that the file has changed
@@ -148,7 +148,7 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
@@ -157,9 +157,9 @@ namespace Microsoft.P4VFS.UnitTest
 				string clientFolder = String.Format(@"{0}\depot\gears1\Binaries\Xenon", clientRoot);
 
 				// Now sync to the head revision
-				DepotSyncResult syncResult = depotClient.Sync(String.Format("{0}\\...", clientFolder), new DepotRevisionHead(), syncType, DepotSyncMethod.Virtual);
+				DepotSyncResult syncResult = depotClient.Sync(String.Format("{0}\\...", clientFolder), new DepotRevisionHead(), syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 				Assert(Directory.Exists(clientFolder), "Directory Path should exist.");
 					
 				foreach (string file in Directory.GetFiles(clientFolder, "*", SearchOption.AllDirectories).ToArray())
@@ -191,7 +191,7 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 				
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
@@ -208,9 +208,9 @@ namespace Microsoft.P4VFS.UnitTest
 				string rootFolder = Path.GetDirectoryName(writableFile);
 				{
 					string folderSpec = String.Format(@"{0}\...@5", rootFolder);
-					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					Assert(syncResult?.Status == DepotSyncStatus.Success);
-					Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 10);
+					Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 10);
 					Assert(FileUtilities.GetDirectorySize(rootFolder) > 0);
 					Assert(FileUtilities.GetDirectoryFileCount(clientRoot) == 10);
 					Assert(File.Exists(writableFile));
@@ -222,9 +222,9 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 				{
 					string folderSpec = String.Format(@"{0}\...@6", rootFolder);
-					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					Assert(syncResult?.Status == DepotSyncStatus.Success);
-					Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+					Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 					Assert(FileUtilities.GetDirectorySize(rootFolder) > 0);
 					Assert(File.Exists(writableFile));
 					Assert(FileUtilities.IsReadOnly(writableFile) == false);
@@ -235,9 +235,9 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 				{
 					string folderSpec = String.Format(@"{0}\...@7", rootFolder);
-					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					Assert(syncResult?.Status == DepotSyncStatus.Success);
-					Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+					Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 					Assert(FileUtilities.GetDirectorySize(rootFolder) > 0);
 					Assert(File.Exists(writableFile));
 					Assert(FileUtilities.IsReadOnly(writableFile) == false);
@@ -248,9 +248,9 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 				{
 					string folderSpec = String.Format(@"{0}\...@5", rootFolder);
-					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					DepotSyncResult syncResult = depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					Assert(syncResult?.Status == DepotSyncStatus.Success);
-					Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
+					Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() > 0);
 					Assert(FileUtilities.GetDirectorySize(rootFolder) > 0);
 					Assert(File.Exists(writableFile));
 					Assert(FileUtilities.IsReadOnly(writableFile) == true);
@@ -269,7 +269,7 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 				
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
@@ -278,7 +278,7 @@ namespace Microsoft.P4VFS.UnitTest
 				string writableFile = String.Format(@"{0}\depot\tools\dev\bin\studio\maya\scripts\python\Utilities\shaderTools.py", clientRoot);
 				{
 					string folderSpec = String.Format("{0}@8", writableFile);
-					depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					Assert(IsPlaceholderFile(writableFile));
 					DepotResultFStat writableFileStat = depotClient.FStat(new[]{ writableFile });
 					Assert(writableFileStat.Count == 1 && writableFileStat[0].HaveRev == 4);
@@ -290,14 +290,14 @@ namespace Microsoft.P4VFS.UnitTest
 
 				{
 					string folderSpec = String.Format("{0}@6", writableFile);
-					depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					DepotResultFStat writableFileStat = depotClient.FStat(new[]{ writableFile });
 					Assert(writableFileStat.Count == 1 && writableFileStat[0].HaveRev == 2);
 					Assert(DiffAgainstWorkspace(String.Format("{0}#4", writableFile)).LinesTotal == 0);
 				}
 				{
 					string folderSpec = String.Format("{0}@9", writableFile);
-					depotClient.Sync(folderSpec, null, syncType, DepotSyncMethod.Virtual);
+					depotClient.Sync(folderSpec, null, syncFlags, DepotSyncMethod.Virtual);
 					DepotResultFStat writableFileStat = depotClient.FStat(new[]{ writableFile });
 					Assert(writableFileStat.Count == 1 && writableFileStat[0].HaveRev == 5);
 					Assert(DiffAgainstWorkspace(String.Format("{0}#4", writableFile)).LinesTotal == 0);
@@ -499,7 +499,7 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
 				string clientRoot = GetClientRoot(depotClient);
 
-				depotClient.Sync("//depot/gears1/Development/Src/Core/...", null, DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				depotClient.Sync("//depot/gears1/Development/Src/Core/...", null, DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Assert(ReconcilePreview("//depot/gears1/Development/Src/Core").Any() == false);
 
 				string newFile = String.Format(@"{0}\depot\gears1\Development\Src\Core\Src\NewFile.cpp", clientRoot);
@@ -547,7 +547,7 @@ namespace Microsoft.P4VFS.UnitTest
 				for (int racePass = 0; racePass < 4; ++racePass)
 				{
 					string raceFile = String.Format(@"{0}\depot\gears1\Development\Src\Core\Src\Core.cpp", clientRoot);
-					depotClient.Sync(raceFile, null, DepotSyncType.Force, DepotSyncMethod.Virtual);
+					depotClient.Sync(raceFile, null, DepotSyncFlags.Force, DepotSyncMethod.Virtual);
 					Assert(IsPlaceholderFile(raceFile) == true);
 
 					Random random = new Random();
@@ -608,7 +608,7 @@ namespace Microsoft.P4VFS.UnitTest
 				string depotPath = "//depot/gears1/Development/External/nvDXT/...";
 				{
 					int syncRevision = 10;
-					DepotSyncResult syncResults = depotClient.Sync(depotPath, new DepotRevisionChangelist(syncRevision), DepotSyncType.Force, DepotSyncMethod.Virtual);
+					DepotSyncResult syncResults = depotClient.Sync(depotPath, new DepotRevisionChangelist(syncRevision), DepotSyncFlags.Force, DepotSyncMethod.Virtual);
 					Assert(syncResults?.Status == DepotSyncStatus.Success);
 					Assert(syncResults.Modifications?.Count() == 12);
 					Assert(syncResults.Modifications.Any(a => a.SyncActionType != DepotSyncActionType.Added) == false);
@@ -617,7 +617,7 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 				{
 					int syncRevision = 11;
-					DepotSyncResult syncResults = depotClient.Sync(depotPath, new DepotRevisionChangelist(syncRevision), DepotSyncType.Force, DepotSyncMethod.Virtual);
+					DepotSyncResult syncResults = depotClient.Sync(depotPath, new DepotRevisionChangelist(syncRevision), DepotSyncFlags.Force, DepotSyncMethod.Virtual);
 					Assert(syncResults?.Status == DepotSyncStatus.Success);
 					Assert(syncResults.Modifications?.Count() == 18);
 					Assert(syncResults.Modifications.Count(a => a.SyncActionType == DepotSyncActionType.Deleted) == 6);
@@ -706,20 +706,20 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
 				DepotSyncResult syncResult;
 				
-				syncResult = depotClient.Sync("//fenix/main/tools/...", null, DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync("//fenix/main/tools/...", null, DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Assert(syncResult != null);
 				Assert(syncResult.Status == DepotSyncStatus.Error);
 				Assert(syncResult.Modifications.Count() == 1);
 				Assert(syncResult.Modifications[0].SyncActionType == DepotSyncActionType.NotInClientView);
 
-				syncResult = depotClient.Sync("//depot/gears1/Binaries/...@vfs_bad_label", null, DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync("//depot/gears1/Binaries/...@vfs_bad_label", null, DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Assert(syncResult != null);
 				Assert(syncResult.Status == DepotSyncStatus.Error);
 				Assert(syncResult.Modifications.Count() == 1);
 				Assert(syncResult.Modifications[0].SyncActionType == DepotSyncActionType.GenericError);
 				Assert(syncResult.Modifications[0].Message == "Invalid changelist/client/label/date '@vfs_bad_label'.");
 
-				syncResult = depotClient.Sync("//depot/gears1/Binaries/...", new DepotRevisionLabel("vfs_bad_label"), DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				syncResult = depotClient.Sync("//depot/gears1/Binaries/...", new DepotRevisionLabel("vfs_bad_label"), DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Assert(syncResult != null);
 				Assert(syncResult.Status == DepotSyncStatus.Error);
 				Assert(syncResult.Modifications.Count() == 1);
@@ -757,16 +757,16 @@ namespace Microsoft.P4VFS.UnitTest
 			using (DepotClient depotClient = new DepotClient())
 			{
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
-				Assert(depotClient.Sync(String.Format("{0}\\...", srcFolder), new DepotRevisionChangelist(Int32.Parse(srcRevision)), DepotSyncType.Normal, DepotSyncMethod.Virtual, DepotFlushType.Atomic, srcResidentPattern)?.Status == DepotSyncStatus.Success);
+				Assert(depotClient.Sync(String.Format("{0}\\...", srcFolder), new DepotRevisionChangelist(Int32.Parse(srcRevision)), DepotSyncFlags.Normal, DepotSyncMethod.Virtual, DepotFlushType.Atomic, srcResidentPattern)?.Status == DepotSyncStatus.Success);
 				verifyResidentFiles(false);
 				
 				WorkspaceReset();
-				Assert(depotClient.Sync(String.Format("{0}\\...", srcFolder), new DepotRevisionChangelist(Int32.Parse(srcRevision)), DepotSyncType.Normal, DepotSyncMethod.Virtual, DepotFlushType.Atomic)?.Status == DepotSyncStatus.Success);
+				Assert(depotClient.Sync(String.Format("{0}\\...", srcFolder), new DepotRevisionChangelist(Int32.Parse(srcRevision)), DepotSyncFlags.Normal, DepotSyncMethod.Virtual, DepotFlushType.Atomic)?.Status == DepotSyncStatus.Success);
 				Assert(DepotOperations.Hydrate(depotClient, new DepotSyncOptions{ Files=new[]{ String.Format("{0}\\...", srcFolder) }, SyncResident=srcResidentPattern })?.Status == DepotSyncStatus.Success);
 				verifyResidentFiles(false);
 
 				WorkspaceReset();
-				Assert(depotClient.Sync(String.Format("{0}\\...", srcFolder), new DepotRevisionChangelist(Int32.Parse(srcRevision)), DepotSyncType.Normal, DepotSyncMethod.Virtual, DepotFlushType.Atomic)?.Status == DepotSyncStatus.Success);
+				Assert(depotClient.Sync(String.Format("{0}\\...", srcFolder), new DepotRevisionChangelist(Int32.Parse(srcRevision)), DepotSyncFlags.Normal, DepotSyncMethod.Virtual, DepotFlushType.Atomic)?.Status == DepotSyncStatus.Success);
 				Assert(DepotOperations.Hydrate(depotClient, new DepotSyncOptions{ Files=new[]{ String.Format("{0}\\...", srcFolder) } })?.Status == DepotSyncStatus.Success);
 				verifyResidentFiles(true);
 			}
@@ -868,7 +868,7 @@ namespace Microsoft.P4VFS.UnitTest
 		[TestMethod, Priority(18), TestRemote]
 		public void DepotClientSymlinkSyncTest()
 		{
-			foreach (ServiceSettingsScope settings in EnumerateCommonServiceSyncLineEndSettings().Where(s => s.SyncType == DepotSyncType.Normal))
+			foreach (ServiceSettingsScope settings in EnumerateCommonServiceSyncLineEndSettings().Where(s => s.SyncFlags == DepotSyncFlags.Normal))
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
@@ -907,8 +907,8 @@ namespace Microsoft.P4VFS.UnitTest
 
 					Action<string, string>[] syncActions = new Action<string, string>[] {
 							(path, rev) => Assert(ProcessInfo.ExecuteWait(P4Exe, String.Format("{0} sync \"{1}{2}\"", ClientConfig, path, rev), echo:true) == 0),
-							(path, rev) => Assert(depotClient.Sync(path, DepotRevision.FromString(rev), DepotSyncType.Normal, DepotSyncMethod.Virtual)?.Modifications?.Count() == 1),
-							(path, rev) => Assert(depotClient.Sync(path, DepotRevision.FromString(rev), DepotSyncType.Normal, DepotSyncMethod.Regular)?.Modifications?.Count() == 1),
+							(path, rev) => Assert(depotClient.Sync(path, DepotRevision.FromString(rev), DepotSyncFlags.Normal, DepotSyncMethod.Virtual)?.Modifications?.Count() == 1),
+							(path, rev) => Assert(depotClient.Sync(path, DepotRevision.FromString(rev), DepotSyncFlags.Normal, DepotSyncMethod.Regular)?.Modifications?.Count() == 1),
 							(path, rev) => Assert(ProcessInfo.ExecuteWait(P4vfsExe, String.Format("{0} sync -t \"{1}{2}\"", ClientConfig, path, rev), echo:true) == 0),
 							(path, rev) => Assert(ProcessInfo.ExecuteWait(P4vfsExe, String.Format("{0} sync -s \"{1}{2}\"", ClientConfig, path, rev), echo:true) == 0),
 					};
@@ -916,7 +916,7 @@ namespace Microsoft.P4VFS.UnitTest
 					for (int syncActionIndex = 0; syncActionIndex < syncActions.Length; ++syncActionIndex)
 					{
 						var syncAction = syncActions[syncActionIndex];
-						depotClient.Sync("//...", new DepotRevisionNone(), DepotSyncType.Force, DepotSyncMethod.Regular);
+						depotClient.Sync("//...", new DepotRevisionNone(), DepotSyncFlags.Force, DepotSyncMethod.Regular);
 						Assert(File.Exists(srcClientSymlink) == false && File.Exists(srcClientTarget) == false);
 						Assert(Directory.Exists(clientRoot) == false || FileUtilities.GetDirectoryFileCount(clientRoot) == 0);
 
@@ -955,7 +955,7 @@ namespace Microsoft.P4VFS.UnitTest
 				for (int racePass = 0; racePass < 2; ++racePass)
 				{
 					string clientFolder = String.Format(@"{0}\depot\gears3\GearGame\Movies", clientRoot);
-					depotClient.Sync(String.Format("{0}\\...@14", clientFolder), null, DepotSyncType.Force, DepotSyncMethod.Virtual);
+					depotClient.Sync(String.Format("{0}\\...@14", clientFolder), null, DepotSyncFlags.Force, DepotSyncMethod.Virtual);
 					
 					string[] clientFiles = Directory.EnumerateFiles(clientFolder).ToArray();
 					Assert(clientFiles.Length == 21);
@@ -1093,7 +1093,7 @@ namespace Microsoft.P4VFS.UnitTest
 				string invalidServer = "p4-localhost4.invalid.domain:1666";
 				string validServer = _P4Port;
 
-				depotClient.Sync(srcFile, new DepotRevisionHead(), DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				depotClient.Sync(srcFile, new DepotRevisionHead(), DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Assert(IsPlaceholderFile(srcFile));
 
 				FilePopulateInfo popInfoBefore = NativeMethods.GetFilePopulateInfo(srcFile);
@@ -1311,11 +1311,11 @@ namespace Microsoft.P4VFS.UnitTest
 				string clientRoot = GetClientRoot(depotClient);
 
 				string largeFile = String.Format(@"{0}\depot\gears1\Development\Src\Core\Src\Core.cpp", clientRoot);
-				depotClient.Sync(largeFile, new DepotRevisionNumber(1), DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				depotClient.Sync(largeFile, new DepotRevisionNumber(1), DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Int64 largeFileSize = FileUtilities.GetFileLength(largeFile);
 
 				string smallFile = String.Format(@"{0}\depot\gears1\Development\Src\Core\Src\BitArray.cpp", clientRoot);
-				depotClient.Sync(smallFile, new DepotRevisionNumber(1), DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				depotClient.Sync(smallFile, new DepotRevisionNumber(1), DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Int64 smallFileSize = FileUtilities.GetFileLength(smallFile);
 
 				Assert(largeFileSize > smallFileSize);
@@ -1504,7 +1504,7 @@ namespace Microsoft.P4VFS.UnitTest
 
 				var AssertSyncEmpty = new Action<Func<DepotSyncResult>>(doSync =>
 				{
-					DepotSyncResult syncResult = depotClient.Sync("//...", null, DepotSyncType.Flush|DepotSyncType.Quiet);
+					DepotSyncResult syncResult = depotClient.Sync("//...", null, DepotSyncFlags.Flush|DepotSyncFlags.Quiet);
 					Assert(syncResult != null && syncResult.Modifications != null);
 					Assert((syncResult.Status == DepotSyncStatus.Success && syncResult.Modifications.Length > clientFileCount) || 
 						   (syncResult.Status == DepotSyncStatus.Warning && syncResult.Modifications.Length == 1 && syncResult.Modifications[0].SyncActionType == DepotSyncActionType.UpToDate));
@@ -1529,8 +1529,8 @@ namespace Microsoft.P4VFS.UnitTest
 
 				foreach (DepotSyncMethod syncMethod in new[]{ DepotSyncMethod.Regular, DepotSyncMethod.Virtual })
 				{
-					AssertSyncEmpty(() => depotClient.Sync("", null, DepotSyncType.Normal, syncMethod));
-					AssertSyncEmpty(() => depotClient.Sync(new DepotSyncOptions{ SyncType=DepotSyncType.Normal, SyncMethod=syncMethod }));
+					AssertSyncEmpty(() => depotClient.Sync("", null, DepotSyncFlags.Normal, syncMethod));
+					AssertSyncEmpty(() => depotClient.Sync(new DepotSyncOptions{ SyncFlags=DepotSyncFlags.Normal, SyncMethod=syncMethod }));
 				}
 
 				foreach (string syncOption in EnumerateCommonConsoleSyncOptions())
@@ -1654,15 +1654,15 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
 				string clientRoot = GetClientRoot(depotClient);
 
-				DepotSyncResult syncResult = depotClient.Sync("//depot/tools/dev/external/packages/thirdparty/microsoft/...", null, syncType, DepotSyncMethod.Virtual);
+				DepotSyncResult syncResult = depotClient.Sync("//depot/tools/dev/external/packages/thirdparty/microsoft/...", null, syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 11);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 11);
 				string[] srcFiles = Directory.GetFiles(clientRoot, "*", SearchOption.AllDirectories);
 				Assert(srcFiles.Length == 11);
 				foreach (string srcFile in srcFiles)
@@ -1694,7 +1694,7 @@ namespace Microsoft.P4VFS.UnitTest
 				// Sync the file to the start revision and verify consistent state
 				string clientFile = startFStat.ClientFile;
 				Assert(String.IsNullOrEmpty(clientFile) == false);
-				DepotSyncResult syncResult = depotClient.Sync(depotFile, new DepotRevisionNumber(startRev), DepotSyncType.Normal, syncMethod);
+				DepotSyncResult syncResult = depotClient.Sync(depotFile, new DepotRevisionNumber(startRev), DepotSyncFlags.Normal, syncMethod);
 				Assert(syncResult.Status == DepotSyncStatus.Success);
 				Assert(syncResult.Modifications?.Count() == 1);
 				Assert(IsPlaceholderFile(clientFile) == (syncMethod == DepotSyncMethod.Virtual));
@@ -1704,7 +1704,7 @@ namespace Microsoft.P4VFS.UnitTest
 				using (FileStream stream = File.OpenRead(clientFile))
 				{
 					// Sync the file to the end revision, which will fail, and verify consistent state still at start revision
-					syncResult = depotClient.Sync(depotFile, new DepotRevisionNumber(endRev), DepotSyncType.Normal, syncMethod);
+					syncResult = depotClient.Sync(depotFile, new DepotRevisionNumber(endRev), DepotSyncFlags.Normal, syncMethod);
 					Assert(syncResult.Status == DepotSyncStatus.Error);
 					Assert(syncResult.Modifications?.Count() > 0);
 					Assert(IsPlaceholderFile(clientFile) == false);
@@ -1714,7 +1714,7 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 
 				// Sync the file to the end revision, which will succeed, and verify consistent state
-				syncResult = depotClient.Sync(depotFile, new DepotRevisionNumber(endRev), DepotSyncType.Normal, syncMethod);
+				syncResult = depotClient.Sync(depotFile, new DepotRevisionNumber(endRev), DepotSyncFlags.Normal, syncMethod);
 				Assert(syncResult.Status == DepotSyncStatus.Success);
 				Assert(syncResult.Modifications?.Count() == 1);
 				Assert(IsPlaceholderFile(clientFile) == (syncMethod == DepotSyncMethod.Virtual));
@@ -1823,7 +1823,7 @@ namespace Microsoft.P4VFS.UnitTest
 				string depotFolder = "//depot/gears1/Development/Src/Core";
 
 				// Perform a sync through the service. We expect connections to be closed when done (not cached)
-				Assert(service.Sync(config, new DepotSyncOptions{ Files=new[]{ depotFolder+"/..." }, SyncType=DepotSyncType.Force, SyncMethod=DepotSyncMethod.Virtual }) == DepotSyncStatus.Success);
+				Assert(service.Sync(config, new DepotSyncOptions{ Files=new[]{ depotFolder+"/..." }, SyncFlags=DepotSyncFlags.Force, SyncMethod=DepotSyncMethod.Virtual }) == DepotSyncStatus.Success);
 
 				// Reconcile the folder using p4.exe. There will be one or more cached service connections
 				Assert(ReconcilePreview(depotFolder).Any() == false);
@@ -1897,7 +1897,7 @@ namespace Microsoft.P4VFS.UnitTest
 				string clientFolder = Path.Combine(clientRoot, "depot\\gears1\\Development\\Src");
 				string clientSubFolder = Path.Combine(clientFolder, "Core\\Inc");
 
-				DepotSyncResult syncResult = sourceDepotClient.Sync(String.Format("{0}\\...", clientFolder), null, DepotSyncType.Normal, DepotSyncMethod.Virtual);
+				DepotSyncResult syncResult = sourceDepotClient.Sync(String.Format("{0}\\...", clientFolder), null, DepotSyncFlags.Normal, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
 				Assert(ReconcilePreview(clientSubFolder).Any() == false);
 
@@ -1984,16 +1984,16 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				using (settings) {
 				using (DepotClient depotClient = new DepotClient()) {
-				DepotSyncType syncType = settings.SyncType.Value;
+				DepotSyncFlags syncFlags = settings.SyncFlags.Value;
 
 				WorkspaceReset();
 				Assert(depotClient.Connect(_P4Port, _P4Client, _P4User));
 				string clientRoot = GetClientRoot(depotClient);
 				string clientFolder = String.Format("{0}\\depot\\tools\\dev\\documentation", clientRoot);
 
-				DepotSyncResult syncResult = depotClient.Sync(String.Format("{0}\\...", clientFolder), null, syncType, DepotSyncMethod.Virtual);
+				DepotSyncResult syncResult = depotClient.Sync(String.Format("{0}\\...", clientFolder), null, syncFlags, DepotSyncMethod.Virtual);
 				Assert(syncResult?.Status == DepotSyncStatus.Success);
-				Assert(syncType.HasFlag(DepotSyncType.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 7);
+				Assert(syncFlags.HasFlag(DepotSyncFlags.IgnoreOutput) ? syncResult.Modifications == null : syncResult.Modifications.Count() == 7);
 				string[] srcFiles = Directory.GetFiles(clientRoot, "*", SearchOption.AllDirectories);
 				Assert(srcFiles.Length == 7);
 				HashSet<string> srcFileSet = srcFiles.Select(path => Regex.Replace(path, String.Format(@"^{0}", Regex.Escape(clientFolder)), "", RegexOptions.IgnoreCase)).ToHashSet();

--- a/source/P4VFS.UnitTest/Source/UnitTestInstall.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestInstall.cs
@@ -46,11 +46,7 @@ namespace Microsoft.P4VFS.UnitTest
 			AssertRetry(() => VirtualFileSystem.IsServiceReady(), message:"IsServiceReady");
 			AssertRetry(() => VirtualFileSystem.IsVirtualFileSystemAvailable(), message:"IsVirtualFileSystemAvailable");
 
-			ushort major = 0; 
-			ushort minor = 0; 
-			ushort build = 0;
-			ushort revision = 0;
-			Assert(CoreInterop.NativeMethods.GetDriverVersion(ref major, ref minor, ref build, ref revision));
+			Assert(CoreInterop.NativeMethods.GetDriverVersion(out ushort major, out ushort minor, out ushort build, out ushort revision));
 			Assert(CoreInterop.NativeConstants.VersionMajor == major, "VersionMajor mismatch");
 			Assert(CoreInterop.NativeConstants.VersionMinor == minor, "VersionMinor mismatch");
 			Assert(CoreInterop.NativeConstants.VersionBuild == build || IsTestingDevConfig() == false, "VersionBuild mismatch");

--- a/source/P4VFS.UnitTest/Source/UnitTestInterop.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestInterop.cs
@@ -26,8 +26,6 @@ namespace Microsoft.P4VFS.UnitTest
 				}
 			}
 
-			WorkspaceReset();
-
 			CoreInterop.TestContextInterop context = new CoreInterop.TestContextInterop();
 			context.m_Environment = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 			context.m_Environment["P4USER"] = _P4User;
@@ -36,6 +34,10 @@ namespace Microsoft.P4VFS.UnitTest
 			context.m_Environment["P4ROOT"] = GetClientRoot();
 			context.m_Environment["P4VFS_EXE"] = P4vfsExe;
 			context.m_Environment["P4VFS_EXE_CONFIG"] = ClientConfig.ToString();
+			context.m_Environment["P4_EXE"] = P4Exe;
+			context.m_Environment["INSTALLED_P4VFS_EXE"] = InstalledP4vfsExe;
+			context.m_Environment["IS_TEST_REMOTE"] = IsTestRemote.ToString();
+			context.m_Environment["SYSINTERNALS_FOLDER"] = SysInternalsFolder;
 			context.m_ReconcilePreviewAny = (s) => this.ReconcilePreview(s).Any();
 			context.m_WorkspaceReset = () => this.WorkspaceReset();
 			context.m_IsPlaceholderFile = (s) => this.IsPlaceholderFile(s);

--- a/source/P4VFS.UnitTest/Source/UnitTestRemote.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestRemote.cs
@@ -68,7 +68,7 @@ namespace Microsoft.P4VFS.UnitTest
 
 		private int RemoteExecuteWait(string cmd, bool admin=false, bool shell=false, bool copy=false, StringBuilder stdout=null)
 		{
-			return ProcessInfo.RemoteExecuteWait(cmd, RemoteHost, RemoteUser, RemotePasswd, admin:admin, shell:shell, copy:copy, stdout:stdout, interactive:true);
+			return ProcessInfo.RemoteExecuteWait(cmd, RemoteHost, RemoteUser, RemotePasswd, admin:admin, shell:shell, copy:copy, stdout:stdout, interactive:true, sysInternalsFolder:SysInternalsFolder);
 		}
 
 		private string GetRequiredEnvironmentVariable(string name)

--- a/source/P4VFS.props
+++ b/source/P4VFS.props
@@ -65,7 +65,7 @@
     <P4VFSUnitTestBuildDir>$(P4VFSBuildDir)/$(P4VFSUnitTestName)</P4VFSUnitTestBuildDir>
 
     <!-- Perforce API -->
-    <PerforceApiVersion>2021.2</PerforceApiVersion>
+    <PerforceApiVersion>2023.1</PerforceApiVersion>
     <PerforceApiConfiguration>$(P4VFSConfiguration)</PerforceApiConfiguration>
     <PerforceApiDir>$(P4VFSExternalDir)/P4API/$(PerforceApiVersion)</PerforceApiDir>
     <PerforceApiIncludeDir>$(PerforceApiDir)/include</PerforceApiIncludeDir>
@@ -73,7 +73,7 @@
     <PerforceApiLibFiles>libclient.lib;libp4api.lib;libp4script.lib;libp4script_c.lib;libp4script_curl.lib;libp4script_sqlite.lib;librpc.lib;libsupp.lib</PerforceApiLibFiles>
 
     <!-- OpenSSL -->
-    <OpenSSLApiVersion>1.1.1t</OpenSSLApiVersion>
+    <OpenSSLApiVersion>1.1.1v</OpenSSLApiVersion>
     <OpenSSLApiConfiguration>$(P4VFSConfiguration)</OpenSSLApiConfiguration>
     <OpenSSLApiDir>$(P4VFSExternalDir)/OpenSSL/$(OpenSSLApiVersion)</OpenSSLApiDir>
     <OpenSSLApiIncludeDir>$(OpenSSLApiDir)/include</OpenSSLApiIncludeDir>

--- a/source/P4VFS.props
+++ b/source/P4VFS.props
@@ -65,7 +65,7 @@
     <P4VFSUnitTestBuildDir>$(P4VFSBuildDir)/$(P4VFSUnitTestName)</P4VFSUnitTestBuildDir>
 
     <!-- Perforce API -->
-    <PerforceApiVersion>2023.1</PerforceApiVersion>
+    <PerforceApiVersion>2023.2</PerforceApiVersion>
     <PerforceApiConfiguration>$(P4VFSConfiguration)</PerforceApiConfiguration>
     <PerforceApiDir>$(P4VFSExternalDir)/P4API/$(PerforceApiVersion)</PerforceApiDir>
     <PerforceApiIncludeDir>$(PerforceApiDir)/include</PerforceApiIncludeDir>


### PR DESCRIPTION
Version [1.27.0.0]
* New sync -c option to force the placeholder file size to be the expected workspace 
  file size, instead of server file size. This requires server 2023.1 or later.
* Updating to P4API 2023.2 and OpenSSL 1.1.1v. UnitTest now uses p4d.exe/p4.exe 2023.1
* P4VFS.External checksum verification fix to handle unexpected whitespace around SHA256
* Driver IRP_MJ_CREATE PostCreate callback fix for properly ignoring reparse on non-P4VFS 
  files with FileTag matching our P4VFS_REPARSE_TAG.
* Driver now requires process to be elevated in order to set control paramters (p4vfs ctrl)
* Addition of DepotClient accessor for server protocol level used for testing for server 
  features and unicode behavior
* Additional tests for elevated access requirements for internal p4vfsflt control port 
  operations
* Fixing stdout display of native unit test assertions and other inner assertions
* Fixing bug where "Text" would appear at the top of the Setup details output.
