### PR TITLE
1.27.1.0 including support for Windows DevDrive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.userosscache
 *.sln.docstates
 *.userprefs
+/debug.log
 /external/*/**
 !/external/*/*.Module.cs
 /intermediate/

--- a/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
+++ b/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
@@ -90,13 +90,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core">
-      <Version>1.36.0</Version>
+      <Version>1.38.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
       <Version>1.10.4</Version>
     </PackageReference>
     <PackageReference Include="Azure.Security.KeyVault.Secrets">
-      <Version>4.5.0</Version>
+      <Version>4.6.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Storage.Blobs">
       <Version>12.19.1</Version>
@@ -105,7 +105,9 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.8.0</Version>
+      <Version>6.9.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -4,6 +4,7 @@ Version [1.27.1.0]
 * Now also ignoring specdef tag from P4API results, similar to P4API.NET
 * The P4VFS install now configures the driver as allowed by Windows Dev Drive, and
   the uninstall will remove this exemption.  
+* Additional native unit tests for windows registry utilities
 
 Version [1.27.0.0]
 * New sync -c option to force the placeholder file size to be the expected workspace 

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -2,9 +2,9 @@ Microsoft P4VFS Release Notes
 
 Version [1.27.1.0]
 * Now also ignoring specdef tag from P4API results, similar to P4API.NET
-* The P4VFS install now configures the driver as allowed by Windows Dev Drive, and
+* The P4VFS install now configures the driver as allowed by Windows DevDrive, and
   the uninstall will remove this exemption.  
-* Additional native unit tests for windows registry utilities and devdrv installation
+* Additional native unit tests for windows registry utilities and DevDrive installation
 * Additional DevDrive unit tests with ReFS virtual hard drive 
 
 Version [1.27.0.0]

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,10 @@
 Microsoft P4VFS Release Notes
 
+Version [1.27.1.0]
+* Now also ignoring specdef tag from P4API results, similar to P4API.NET
+* The P4VFS install now configures the driver as allowed by Windows Dev Drive, and
+  the uninstall will remove this exemption.  
+
 Version [1.27.0.0]
 * New sync -c option to force the placeholder file size to be the expected workspace 
   file size, instead of server file size. This requires server 2023.1 or later.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -5,6 +5,7 @@ Version [1.27.1.0]
 * The P4VFS install now configures the driver as allowed by Windows Dev Drive, and
   the uninstall will remove this exemption.  
 * Additional native unit tests for windows registry utilities and devdrv installation
+* Additional DevDrive unit tests with ReFS virtual hard drive 
 
 Version [1.27.0.0]
 * New sync -c option to force the placeholder file size to be the expected workspace 

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -4,7 +4,7 @@ Version [1.27.1.0]
 * Now also ignoring specdef tag from P4API results, similar to P4API.NET
 * The P4VFS install now configures the driver as allowed by Windows Dev Drive, and
   the uninstall will remove this exemption.  
-* Additional native unit tests for windows registry utilities
+* Additional native unit tests for windows registry utilities and devdrv installation
 
 Version [1.27.0.0]
 * New sync -c option to force the placeholder file size to be the expected workspace 

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -864,6 +864,10 @@ Available commands:
 				VirtualFileSystemLog.Info("Driver install {0}", status.ToStatusString());
 				result &= status;
 
+				VirtualFileSystemLog.Info("Installing DevDrive {0}", VirtualFileSystem.DriverTitle);
+				bool devdrive = DriverOperations.SetDevDriveFilterAllowed(VirtualFileSystem.DriverTitle, true) == WindowsInterop.S_OK;
+				VirtualFileSystemLog.Info("DevDrive install {0}", devdrive.ToStatusString());
+
 				VirtualFileSystemLog.Info("Loading {0}", VirtualFileSystem.DriverTitle);
 				status = VirtualFileSystem.LoadDriver();
 				VirtualFileSystemLog.Info("Driver load {0}", status.ToStatusString());
@@ -959,6 +963,10 @@ Available commands:
 				bool status = VirtualFileSystem.UnloadDriver();
 				VirtualFileSystemLog.Info("Driver unload {0}", status.ToStatusString());
 				result &= status;
+
+				VirtualFileSystemLog.Info("Uninstalling DevDrive {0}", VirtualFileSystem.DriverTitle);
+				bool devdrive = DriverOperations.SetDevDriveFilterAllowed(VirtualFileSystem.DriverTitle, false) == WindowsInterop.S_OK;
+				VirtualFileSystemLog.Info("DevDrive uninstall {0}", devdrive.ToStatusString());
 
 				VirtualFileSystemLog.Info("Uninstalling {0}", VirtualFileSystem.DriverTitle);
 				status = VirtualFileSystem.UninstallDriver();

--- a/source/P4VFS.Core/Include/DriverOperations.h
+++ b/source/P4VFS.Core/Include/DriverOperations.h
@@ -25,6 +25,12 @@ namespace DriverOperations {
 		);
 
 	P4VFS_CORE_API HRESULT
+	SetDevDriveFilterAllowed(
+		const WCHAR* driverName,
+		bool isAllowed
+		);
+
+	P4VFS_CORE_API HRESULT
 	GetLoadedFilters(
 		FileCore::StringArray& driverNames
 		);

--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -603,16 +603,22 @@ namespace FileCore {
 			return std::any_of(elements.begin(), elements.end(), predicate);
 		}
 
-		template <typename ArrayType, typename ValueType>
-		static void Remove(ArrayType& elements, const ValueType& v)
+		template <typename ArrayType, typename Predicate>
+		static void RemoveIf(ArrayType& elements, Predicate predicate)
 		{
 			for (ArrayType::iterator i = elements.begin(); i != elements.end();)
 			{
-				if (*i == v)
+				if (predicate(*i))
 					i = elements.erase(i);
 				else
 					++i;
 			}
+		}
+
+		template <typename ArrayType, typename ValueType>
+		static void Remove(ArrayType& elements, const ValueType& v)
+		{
+			return RemoveIf(elements, [&v](const auto& i) -> bool { return i == v; });
 		}
 
 		template <typename DstArrayType, typename SrcArrayType>
@@ -709,10 +715,21 @@ namespace FileCore {
 		static String			GetProcessNameById(DWORD processID);
 	};
 
+	struct RegistryValue
+	{
+		DWORD m_Type = REG_NONE;
+		Array<BYTE> m_Data;
+
+		P4VFS_CORE_API String					ToString(LSTATUS* pstatus = nullptr) const;
+		P4VFS_CORE_API StringArray				ToStringArray(LSTATUS* pstatus = nullptr) const;
+		P4VFS_CORE_API static RegistryValue		FromString(const String& value);
+		P4VFS_CORE_API static RegistryValue		FromStringArray(const StringArray& value);
+	};
+
 	struct P4VFS_CORE_API RegistryInfo
 	{
-		static String	GetValueAsString(HKEY hKey, const wchar_t* valueName, LSTATUS* pstatus = nullptr);
-		static String	GetKeyValueAsString(HKEY hKey, const wchar_t* subkeyName, const wchar_t* valueName, LSTATUS* pstatus = nullptr);
+		static RegistryValue	GetValue(HKEY hKey, const wchar_t* valueName, LSTATUS* pstatus = nullptr);
+		static RegistryValue	GetKeyValue(HKEY hKey, const wchar_t* subkeyName, const wchar_t* valueName, LSTATUS* pstatus = nullptr);
 	};
 
 	#define P4VFS_ENUM_TO_STRING_APPEND_FLAG(s, v, ns, ev) \

--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -720,6 +720,7 @@ namespace FileCore {
 		DWORD m_Type = REG_NONE;
 		Array<BYTE> m_Data;
 
+		P4VFS_CORE_API bool						IsValid() const;
 		P4VFS_CORE_API String					ToString(LSTATUS* pstatus = nullptr) const;
 		P4VFS_CORE_API StringArray				ToStringArray(LSTATUS* pstatus = nullptr) const;
 		P4VFS_CORE_API static RegistryValue		FromString(const String& value);
@@ -730,6 +731,8 @@ namespace FileCore {
 	{
 		static RegistryValue	GetValue(HKEY hKey, const wchar_t* valueName, LSTATUS* pstatus = nullptr);
 		static RegistryValue	GetKeyValue(HKEY hKey, const wchar_t* subkeyName, const wchar_t* valueName, LSTATUS* pstatus = nullptr);
+		static LSTATUS			SetValue(HKEY hKey, const wchar_t* valueName, const RegistryValue& value);
+		static LSTATUS			SetKeyValue(HKEY hKey, const wchar_t* subkeyName, const wchar_t* valueName, const RegistryValue& value);
 	};
 
 	#define P4VFS_ENUM_TO_STRING_APPEND_FLAG(s, v, ns, ev) \

--- a/source/P4VFS.Core/P4VFS.Core.vcxproj
+++ b/source/P4VFS.Core/P4VFS.Core.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="Tests\TestFileOperations.cpp" />
     <ClCompile Include="Tests\TestFileSystem.cpp" />
     <ClCompile Include="Tests\TestRegistry.cpp" />
+    <ClCompile Include="Tests\TestRegistryInfo.cpp" />
     <ClCompile Include="Tests\TestServiceOperations.cpp" />
     <ClCompile Include="Tests\TestStringInfo.cpp" />
     <ClCompile Include="Tests\TestThreadPool.cpp" />

--- a/source/P4VFS.Core/P4VFS.Core.vcxproj.filters
+++ b/source/P4VFS.Core/P4VFS.Core.vcxproj.filters
@@ -232,5 +232,8 @@
     <ClCompile Include="Source\DepotReconfig.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="Tests\TestRegistryInfo.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -268,7 +268,7 @@ public:
 		StrRef var, val;
 		for (int32_t varIndex = 0; varList->GetVar(varIndex, var, val); ++varIndex)
 		{
-			if (var != P4Tag::v_func && var != P4Tag::v_specFormatted)
+			if (var != P4Tag::v_specdef && var != P4Tag::v_specFormatted && var != P4Tag::v_func)
 				TagList().back()->m_Fields.insert(Map<DepotString, DepotString>::value_type(var.Text(), val.Text()));
 		}
 

--- a/source/P4VFS.Core/Source/DriverOperations.cpp
+++ b/source/P4VFS.Core/Source/DriverOperations.cpp
@@ -109,6 +109,58 @@ IsFilterLoaded(
 }
 
 HRESULT
+SetDevDriveFilterAllowed(
+	const WCHAR* driverName,
+	bool isAllowed
+	)
+{
+	if (FileCore::StringInfo::IsNullOrEmpty(driverName))
+	{
+		return HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER);
+	}
+
+	const WCHAR* fltMgrKeyName = TEXT("HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\FilterManager");
+	const WCHAR* fltMgrDevDriveAttachPolicyValueName = TEXT("FltmgrDevDriveAttachPolicy");
+	FileCore::StringArray devDriveAllowedList;
+
+	LSTATUS status = ERROR_SUCCESS;
+	FileCore::RegistryValue devDriveValue = FileCore::RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, 
+																				fltMgrKeyName, 
+																				fltMgrDevDriveAttachPolicyValueName, 
+																				&status);
+	
+	if (status == ERROR_SUCCESS && devDriveValue.m_Type == REG_MULTI_SZ)
+	{
+		devDriveAllowedList = devDriveValue.ToStringArray();
+	}
+
+	auto equalsDriverName = [driverName](const FileCore::String& V) -> bool
+	{
+		return FileCore::StringInfo::Stricmp(V.c_str(), driverName) == 0;
+	};
+
+	if (isAllowed)
+	{
+		FileCore::Algo::RemoveIf(devDriveAllowedList, equalsDriverName);
+	}
+	else if (FileCore::Algo::Any(devDriveAllowedList, equalsDriverName) == false)
+	{
+		devDriveAllowedList.push_back(driverName);
+	}
+
+ //       return RtlWriteRegistryValue( RTL_REGISTRY_ABSOLUTE,
+ //                                     fltMgrKeyName,
+ //                                     fltMgrDevDriveAttachPolicyValueName,
+ //                                     REG_MULTI_SZ,
+ //                                     FilterList->Buffer,
+ //                                     FilterList->Length );
+ //
+//	FltiAttachPolicySetAllowList
+ //
+	return S_OK;
+}
+
+HRESULT
 GetLoadedFilters(
 	FileCore::StringArray& driverNames
 	)

--- a/source/P4VFS.Core/Source/FileCore.cpp
+++ b/source/P4VFS.Core/Source/FileCore.cpp
@@ -2297,7 +2297,7 @@ StringArray RegistryValue::ToStringArray(LSTATUS* pstatus) const
 	{
 		status = ERROR_SUCCESS;
 		const WCHAR* p = reinterpret_cast<const wchar_t*>(m_Data.data());
-		const WCHAR* pend = p + (m_Data.size()/sizeof(WCHAR)) + 1;
+		const WCHAR* pend = reinterpret_cast<const wchar_t*>(m_Data.data()+m_Data.size());
 		for (; p < pend; ++p)
 		{
 			if (*p != TEXT('\0'))

--- a/source/P4VFS.Core/Source/FileCore.cpp
+++ b/source/P4VFS.Core/Source/FileCore.cpp
@@ -2275,7 +2275,7 @@ String RegistryValue::ToString(LSTATUS* pstatus) const
 		if (const wchar_t* text = reinterpret_cast<const wchar_t*>(m_Data.data()))
 		{
 			size_t length = m_Data.size()/sizeof(wchar_t);
-			while (length > 0 && text[length])
+			while (length > 0 && text[length-1] == TEXT('\0'))
 			{
 				--length;
 			}

--- a/source/P4VFS.Core/Source/LogDevice.cpp
+++ b/source/P4VFS.Core/Source/LogDevice.cpp
@@ -182,9 +182,9 @@ String LogDeviceFile::GetLogHeaderText() const
 	HKEY hVersionKey = NULL;
 	if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hVersionKey) == ERROR_SUCCESS)
 	{
-		text += StringInfo::Format(L"OS Name: %s\n", RegistryInfo::GetValueAsString(hVersionKey, L"ProductName").c_str());
-		text += StringInfo::Format(L"OS Architecture: %s\n", RegistryInfo::GetValueAsString(hVersionKey, L"BuildLabEx").c_str());
-		text += StringInfo::Format(L"OS Version: %s.%s.%s\n", RegistryInfo::GetValueAsString(hVersionKey, L"CurrentMajorVersionNumber").c_str(), RegistryInfo::GetValueAsString(hVersionKey, L"CurrentMinorVersionNumber").c_str(), RegistryInfo::GetValueAsString(hVersionKey, L"CurrentBuildNumber").c_str());
+		text += StringInfo::Format(L"OS Name: %s\n", RegistryInfo::GetValue(hVersionKey, L"ProductName").ToString().c_str());
+		text += StringInfo::Format(L"OS Architecture: %s\n", RegistryInfo::GetValue(hVersionKey, L"BuildLabEx").ToString().c_str());
+		text += StringInfo::Format(L"OS Version: %s.%s.%s\n", RegistryInfo::GetValue(hVersionKey, L"CurrentMajorVersionNumber").ToString().c_str(), RegistryInfo::GetValue(hVersionKey, L"CurrentMinorVersionNumber").ToString().c_str(), RegistryInfo::GetValue(hVersionKey, L"CurrentBuildNumber").ToString().c_str());
 		RegCloseKey(hVersionKey);
 	}
 

--- a/source/P4VFS.Core/Tests/TestFileInfo.cpp
+++ b/source/P4VFS.Core/Tests/TestFileInfo.cpp
@@ -119,7 +119,7 @@ void TestFileInfoDirectory(const TestContext& context)
 void TestFileInfoLongPathSupport(const TestContext& context)
 {
 	TestUtilities::WorkspaceReset(context);
-	AssertMsg(RegistryInfo::GetKeyValueAsString(HKEY_LOCAL_MACHINE, TEXT("SYSTEM\\CurrentControlSet\\Control\\FileSystem"), TEXT("LongPathsEnabled")) == TEXT("1"), TEXT("Expecting long path support to be enabled on this machine"));
+	AssertMsg(RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, TEXT("SYSTEM\\CurrentControlSet\\Control\\FileSystem"), TEXT("LongPathsEnabled")).ToString() == TEXT("1"), TEXT("Expecting long path support to be enabled on this machine"));
 
 	Assert(FileInfo::IsExtendedPath(FileInfo::ExtendedPathPrefix));
 	Assert(FileInfo::IsExtendedPath(StringInfo::Format(TEXT("%sC:\\Temp"), FileInfo::ExtendedPathPrefix).c_str()));

--- a/source/P4VFS.Core/Tests/TestRegistry.cpp
+++ b/source/P4VFS.Core/Tests/TestRegistry.cpp
@@ -64,3 +64,7 @@ P4VFS_REGISTER_TEST( TestFileOperationsAccessUnelevated,		11004, TestFlags::Expl
 // TestDirectoryOperations
 P4VFS_REGISTER_TEST( TestIterateDirectoryParallel,				12000 )
 
+// TestRegistryInfo
+P4VFS_REGISTER_TEST( TestRegistryInfoInstallKeys,				13000 )
+P4VFS_REGISTER_TEST( TestRegistryInfoKeyValue,					13001 )
+

--- a/source/P4VFS.Core/Tests/TestRegistry.cpp
+++ b/source/P4VFS.Core/Tests/TestRegistry.cpp
@@ -18,6 +18,7 @@ P4VFS_REGISTER_TEST( TestDepotClientIsSymlinkFileType,			10103 )
 P4VFS_REGISTER_TEST( TestResolveFileResidency,					10200 )
 P4VFS_REGISTER_TEST( TestRequireFilterOpLock,					10201 )
 P4VFS_REGISTER_TEST( TestFileAlternateStream,					10202 )
+P4VFS_REGISTER_TEST( TestDevDriveAttachPolicy,					10203 )
 
 // TestStringInfo
 P4VFS_REGISTER_TEST( TestStringInfoHash,						10300 )

--- a/source/P4VFS.Core/Tests/TestRegistryInfo.cpp
+++ b/source/P4VFS.Core/Tests/TestRegistryInfo.cpp
@@ -9,23 +9,48 @@ using namespace Microsoft::P4VFS::TestCore;
 
 struct TestRegistryInfo
 {
-	static void AssertGetKeyValueString(const wchar_t* keyName, const wchar_t* valueName, const wchar_t* value)
+	static void AssertGetKeyValue(const wchar_t* keyName, const wchar_t* valueName, const String& value)
 	{
 		LSTATUS status = -1;
 		RegistryValue regValue = RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, keyName, valueName, &status);
-		Assert(status == ERROR_SUCCESS);
+		Assert(status == ERROR_SUCCESS && regValue.IsValid());
 		String regValueString = regValue.ToString(&status);
-		Assert(status == ERROR_SUCCESS && StringInfo::Strcmp(regValueString.c_str(), value) == 0);
+		Assert(status == ERROR_SUCCESS && regValueString == value);
 	};
 
-	static void AssertGetKeyValueStringArray(const wchar_t* keyName, const wchar_t* valueName, const StringArray& value)
+	static void AssertGetKeyValue(const wchar_t* keyName, const wchar_t* valueName, const StringArray& value)
 	{
 		LSTATUS status = -1;
 		RegistryValue regValue = RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, keyName, valueName, &status);
-		Assert(status == ERROR_SUCCESS);
+		Assert(status == ERROR_SUCCESS && regValue.IsValid());
 		StringArray regValueStringArray = regValue.ToStringArray(&status);
 		Assert(status == ERROR_SUCCESS && regValueStringArray == value);
 	};
+
+	static void AssertSetKeyValue(const wchar_t* keyName, const wchar_t* valueName, const String& value)
+	{
+		LSTATUS status = -1;
+		RegistryValue regValue = RegistryValue::FromString(value);
+		Assert(regValue.IsValid() && regValue.ToString() == value);
+		status = RegistryInfo::SetKeyValue(HKEY_LOCAL_MACHINE, keyName, valueName, regValue);
+		Assert(status == ERROR_SUCCESS);
+	};
+
+	static void AssertSetKeyValue(const wchar_t* keyName, const wchar_t* valueName, const StringArray& value)
+	{
+		LSTATUS status = -1;
+		RegistryValue regValue = RegistryValue::FromStringArray(value);
+		Assert(regValue.IsValid() && regValue.ToStringArray() == value);
+		status = RegistryInfo::SetKeyValue(HKEY_LOCAL_MACHINE, keyName, valueName, regValue);
+		Assert(status == ERROR_SUCCESS);
+	};
+
+	template <typename ValueType>
+	static void AssertSetGetKeyValue(const wchar_t* keyName, const wchar_t* valueName, const ValueType& value)
+	{
+		AssertSetKeyValue(keyName, valueName, value);
+		AssertGetKeyValue(keyName, valueName, value);
+	}
 
 	static void AssertResetTestKey(const wchar_t* keyName)
 	{
@@ -48,11 +73,11 @@ void TestRegistryInfoInstallKeys(const TestContext& context)
 	const String appInstallLocation = RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, hklmAppKeyName, TEXT("InstallLocation")).ToString();
 	Assert(FileInfo::IsDirectory(appInstallLocation.c_str()));
 
-	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("DisplayIcon"), StringInfo::Format(TEXT("%s\\P4VFS.Setup.exe"), appInstallLocation.c_str()).c_str());
-	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("DisplayName"), TEXT("P4VFS"));
-	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("DisplayVersion"), P4VFS_VER_VERSION_STRING);
-	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("UninstallString"), StringInfo::Format(TEXT("\"%s\\P4VFS.Setup.exe\" uninstall"), appInstallLocation.c_str()).c_str());
-	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("Publisher"), TEXT("Microsoft Corporation"));
+	TestRegistryInfo::AssertGetKeyValue(hklmAppKeyName, TEXT("DisplayIcon"), StringInfo::Format(TEXT("%s\\P4VFS.Setup.exe"), appInstallLocation.c_str()));
+	TestRegistryInfo::AssertGetKeyValue(hklmAppKeyName, TEXT("DisplayName"), TEXT("P4VFS"));
+	TestRegistryInfo::AssertGetKeyValue(hklmAppKeyName, TEXT("DisplayVersion"), P4VFS_VER_VERSION_STRING);
+	TestRegistryInfo::AssertGetKeyValue(hklmAppKeyName, TEXT("UninstallString"), StringInfo::Format(TEXT("\"%s\\P4VFS.Setup.exe\" uninstall"), appInstallLocation.c_str()));
+	TestRegistryInfo::AssertGetKeyValue(hklmAppKeyName, TEXT("Publisher"), TEXT("Microsoft Corporation"));
 }
 
 void TestRegistryInfoKeyValue(const TestContext& context)
@@ -61,7 +86,13 @@ void TestRegistryInfoKeyValue(const TestContext& context)
 
 	TestRegistryInfo::AssertResetTestKey(hklmTestKeyName);
 
-	const String cmdMV0 = StringInfo::Format(TEXT("reg add \"HKLM\\%s\" /v MultiTest0 /t REG_MULTI_SZ /d \"Saguenay\\0Trois-Riviéres\""), hklmTestKeyName);
-	Assert(Process::Execute(cmdMV0.c_str(), nullptr, Process::ExecuteFlags::WaitForExit|Process::ExecuteFlags::HideWindow).m_ExitCode == 0);
-	TestRegistryInfo::AssertGetKeyValueStringArray(hklmTestKeyName, TEXT("MultiTest0"), StringArray({TEXT("Saguenay"),TEXT("Trois-Riviéres")}));
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("MultiTest"), StringArray({TEXT("Saguenay"),TEXT("Trois-Riviéres")}));
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("MultiTest"), StringArray({TEXT("Saguenay")}));
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("MultiTest"), StringArray());
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("MultiTest"), StringArray({TEXT("one"),TEXT("two"),TEXT("three"),TEXT("four")}));
+
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("StringTest"), String(TEXT("Sherbrooke")));
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("StringTest"), String(TEXT("")));
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("StringTest"), String(TEXT("Saint-Augustin-de-Desmaures,L'Ancienne-Lorette")));
+	TestRegistryInfo::AssertSetGetKeyValue(hklmTestKeyName, TEXT("StringTest"), String(TEXT("one;two;three;four")));
 }

--- a/source/P4VFS.Core/Tests/TestRegistryInfo.cpp
+++ b/source/P4VFS.Core/Tests/TestRegistryInfo.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+#include "Pch.h"
+#include "TestFactory.h"
+#include "DriverVersion.h"
+
+using namespace Microsoft::P4VFS::FileCore;
+using namespace Microsoft::P4VFS::TestCore;
+
+struct TestRegistryInfo
+{
+	static void AssertGetKeyValueString(const wchar_t* keyName, const wchar_t* valueName, const wchar_t* value)
+	{
+		LSTATUS status = -1;
+		RegistryValue regValue = RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, keyName, valueName, &status);
+		Assert(status == ERROR_SUCCESS);
+		String regValueString = regValue.ToString(&status);
+		Assert(status == ERROR_SUCCESS && StringInfo::Strcmp(regValueString.c_str(), value) == 0);
+	};
+
+	static void AssertGetKeyValueStringArray(const wchar_t* keyName, const wchar_t* valueName, const StringArray& value)
+	{
+		LSTATUS status = -1;
+		RegistryValue regValue = RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, keyName, valueName, &status);
+		Assert(status == ERROR_SUCCESS);
+		StringArray regValueStringArray = regValue.ToStringArray(&status);
+		Assert(status == ERROR_SUCCESS && regValueStringArray == value);
+	};
+
+	static void AssertResetTestKey(const wchar_t* keyName)
+	{
+		HKEY hRootTestKey = NULL;
+		LSTATUS status = RegOpenKeyEx(HKEY_LOCAL_MACHINE, FileInfo::FolderPath(keyName).c_str(), 0, KEY_ALL_ACCESS, &hRootTestKey);
+		Assert(status == ERROR_SUCCESS || status == ERROR_FILE_NOT_FOUND);
+		if (status == ERROR_SUCCESS)
+		{
+			status = RegDeleteTreeW(hRootTestKey, FileInfo::FileName(keyName).c_str());
+			Assert(status == ERROR_SUCCESS || status == ERROR_FILE_NOT_FOUND);
+			RegCloseKey(hRootTestKey);
+		}
+	};
+};
+
+void TestRegistryInfoInstallKeys(const TestContext& context)
+{
+	const wchar_t* hklmAppKeyName = TEXT("SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\P4VFS");
+	
+	const String appInstallLocation = RegistryInfo::GetKeyValue(HKEY_LOCAL_MACHINE, hklmAppKeyName, TEXT("InstallLocation")).ToString();
+	Assert(FileInfo::IsDirectory(appInstallLocation.c_str()));
+
+	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("DisplayIcon"), StringInfo::Format(TEXT("%s\\P4VFS.Setup.exe"), appInstallLocation.c_str()).c_str());
+	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("DisplayName"), TEXT("P4VFS"));
+	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("DisplayVersion"), P4VFS_VER_VERSION_STRING);
+	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("UninstallString"), StringInfo::Format(TEXT("\"%s\\P4VFS.Setup.exe\" uninstall"), appInstallLocation.c_str()).c_str());
+	TestRegistryInfo::AssertGetKeyValueString(hklmAppKeyName, TEXT("Publisher"), TEXT("Microsoft Corporation"));
+}
+
+void TestRegistryInfoKeyValue(const TestContext& context)
+{
+	const wchar_t* hklmTestKeyName = TEXT("SOFTWARE\\Wow6432Node\\Microsoft\\P4VFS\\Test");
+
+	TestRegistryInfo::AssertResetTestKey(hklmTestKeyName);
+
+	const String cmdMV0 = StringInfo::Format(TEXT("reg add \"HKLM\\%s\" /v MultiTest0 /t REG_MULTI_SZ /d \"Saguenay\\0Trois-Riviéres\""), hklmTestKeyName);
+	Assert(Process::Execute(cmdMV0.c_str(), nullptr, Process::ExecuteFlags::WaitForExit|Process::ExecuteFlags::HideWindow).m_ExitCode == 0);
+	TestRegistryInfo::AssertGetKeyValueStringArray(hklmTestKeyName, TEXT("MultiTest0"), StringArray({TEXT("Saguenay"),TEXT("Trois-Riviéres")}));
+}

--- a/source/P4VFS.CoreInterop/Include/DriverOperationsInterop.h
+++ b/source/P4VFS.CoreInterop/Include/DriverOperationsInterop.h
@@ -31,6 +31,11 @@ public:
 		[System::Runtime::InteropServices::Out] array<System::String^>^% driverNames
 		);
 
+	static System::Int32
+	SetDevDriveFilterAllowed(
+		System::String^ driverName,
+		System::Boolean isAllowed
+	);
 };
 
 }}}

--- a/source/P4VFS.CoreInterop/Source/DriverOperationsInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/DriverOperationsInterop.cpp
@@ -50,5 +50,14 @@ DriverOperations::GetLoadedFilters(
 	return hr;
 }
 
+System::Int32
+DriverOperations::SetDevDriveFilterAllowed(
+	System::String^ driverName,
+	System::Boolean isAllowed
+	)
+{
+	return P4VFS::DriverOperations::SetDevDriveFilterAllowed(marshal_as_wstring_c_str(driverName), isAllowed);
+}
+
 }}}
 

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -4,7 +4,7 @@
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					27			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					0			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v

--- a/source/P4VFS.External/P4VFS.External.csproj
+++ b/source/P4VFS.External/P4VFS.External.csproj
@@ -86,7 +86,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.8.0</Version>
+      <Version>6.9.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/P4VFS.UnitTest/Source/UnitTestInstall.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestInstall.cs
@@ -31,6 +31,7 @@ namespace Microsoft.P4VFS.UnitTest
 			AssertRetry(() => VirtualFileSystem.IsDriverReady() == false, message:"IsDriverReady");
 			AssertRetry(() => VirtualFileSystem.IsServiceReady() == false, message:"IsServiceReady");
 			AssertRetry(() => VirtualFileSystem.IsVirtualFileSystemAvailable() == false, message:"IsVirtualFileSystemAvailable");
+			AssertRetry(() => IsDevDriveAllowed() == false, message:"IsDevDriveAllowed");
 		}
 
 		[TestMethod, Priority(1)]
@@ -45,6 +46,7 @@ namespace Microsoft.P4VFS.UnitTest
 			AssertRetry(() => VirtualFileSystem.IsDriverReady(), message:"IsDriverReady");
 			AssertRetry(() => VirtualFileSystem.IsServiceReady(), message:"IsServiceReady");
 			AssertRetry(() => VirtualFileSystem.IsVirtualFileSystemAvailable(), message:"IsVirtualFileSystemAvailable");
+			AssertRetry(() => IsDevDriveAllowed(), message:"IsDevDriveAllowed");
 
 			Assert(CoreInterop.NativeMethods.GetDriverVersion(out ushort major, out ushort minor, out ushort build, out ushort revision));
 			Assert(CoreInterop.NativeConstants.VersionMajor == major, "VersionMajor mismatch");
@@ -434,6 +436,12 @@ namespace Microsoft.P4VFS.UnitTest
 			Match m = Regex.Match(osDescription, @"\.(?<build>\d+)\s*$");
 			Assert(m.Success);
 			return Int32.Parse(m.Groups["build"].Value);
+		}
+
+		public static bool IsDevDriveAllowed()
+		{
+			return ProcessInfo.ExecuteWaitOutput("fsutil.exe", "devdrv query").Lines.
+				Any(line => Regex.IsMatch(line, String.Format(@"(^|\s|,){0}($|\s|,)", VirtualFileSystem.DriverTitle), RegexOptions.IgnoreCase));
 		}
 	}
 }

--- a/source/P4VFS.UnitTest/Source/UnitTestServer.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestServer.cs
@@ -489,8 +489,18 @@ namespace Microsoft.P4VFS.UnitTest
 			return Regex.Replace(fileSpec, @"(/\.\.\.)?([@#].*)?", "");
 		}
 
+		public static string ServerRootFolderOverride
+		{
+			get; set;
+		}
+
 		public static string GetServerRootFolder(string p4Port = null)
 		{
+			// Special case for overriding the server root folder possibly on another drive
+			if (String.IsNullOrEmpty(ServerRootFolderOverride) == false) 
+			{
+				return ServerRootFolderOverride;
+			}
 			return String.Format("{0}\\{1}", UnitTestInstall.GetIntermediateRootFolder(), GetServerPortNumber(p4Port));
 		}
 

--- a/source/P4VFS.natvis
+++ b/source/P4VFS.natvis
@@ -9,5 +9,13 @@
     <DisplayString Condition="offsetBytes != 0">{(wchar_t*)(((char*)this)+offsetBytes)}</DisplayString>
     <StringView Condition="offsetBytes != 0">(wchar_t*)(((char*)this)+offsetBytes),su</StringView>
   </Type>
+
+  <Type Name="Microsoft::P4VFS::FileCore::RegistryValue">
+    <DisplayString Condition="m_Type == 0">Empty</DisplayString>
+    <DisplayString Condition="m_Type == 1">{{ m_Type=REG_SZ, m_Data={((wchar_t*)(m_Data._Mypair._Myval2._Myfirst)),[m_Data.size()/2]} }}</DisplayString>
+    <DisplayString Condition="m_Type == 2">{{ m_Type=REG_EXPAND_SZ, m_Data={((wchar_t*)(m_Data._Mypair._Myval2._Myfirst)),[m_Data.size()/2]} }}</DisplayString>
+    <DisplayString Condition="m_Type == 4">{{ m_Type=REG_DWORD, m_Data={(*(DWORD*)(m_Data._Mypair._Myval2._Myfirst)),x} }}</DisplayString>
+    <DisplayString Condition="m_Type == 7">{{ m_Type=REG_MULTI_SZ, m_Data={((wchar_t*)(m_Data._Mypair._Myval2._Myfirst)),[m_Data.size()/2]} }}</DisplayString>
+  </Type>
   
 </AutoVisualizer>


### PR DESCRIPTION
Version [1.27.1.0]
* Now also ignoring specdef tag from P4API results, similar to P4API.NET
* The P4VFS install now configures the driver as allowed by Windows DevDrive, and
  the uninstall will remove this exemption.  
* Additional native unit tests for windows registry utilities and DevDrive installation
* Additional DevDrive unit tests with ReFS virtual hard drive 