### PR TITLE
Release 1.28.0.0

### DIFF
--- a/.github/workflows/p4vfs-verify.yml
+++ b/.github/workflows/p4vfs-verify.yml
@@ -38,15 +38,15 @@ jobs:
         Write-Output "ImageVersion=$env:ImageVersion" >> $env:GITHUB_ENV
 
     - name: Checkout the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v4.1.7
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.3.1
+      uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x64
 
     - name: Cache OpenSSL ${{env.ImageOS}} ${{env.ImageVersion}}
-      uses: actions/cache@v3.3.0
+      uses: actions/cache@v4.0.2
       with:
         path: |
           external/OpenSSL

--- a/external/OpenSSL/OpenSSL.Module.cs
+++ b/external/OpenSSL/OpenSSL.Module.cs
@@ -12,7 +12,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class OpensslModule : Module
 	{
-		private const string OPENSSL_VERSION = "1.1.1v";
+		private const string OPENSSL_VERSION = "3.3.1";
 		private const string PERL_PACKAGE_NAME = "StrawberryPerl";
 		private const string PERL_VERSION = "5.28.0.1";
 

--- a/external/P4API/P4API.Module.cs
+++ b/external/P4API/P4API.Module.cs
@@ -12,7 +12,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class P4apiModule : Module
 	{
-		private const string P4API_VERSION = "r23.2";
+		private const string P4API_VERSION = "r24.1";
 		private const string P4API_VISUAL_STUDIO_EDITION = "2022";
 
 		public override string Name
@@ -86,11 +86,11 @@ namespace Microsoft.P4VFS.External
 			Dictionary<string, string> checksums = ModuleInfo.LoadChecksumFile(checksumFilePath);
 
 			// Download and deploy the debug P4API
-			string p4apiDbgFile = ModuleInfo.DownloadFileToFolder($"{p4apiUrlRoot}/bin.ntx64/p4api_vs{p4apiVisualStudioEdition}_dyn_vsdebug_openssl1.1.1.zip", workingFolder, checksums);
+			string p4apiDbgFile = ModuleInfo.DownloadFileToFolder($"{p4apiUrlRoot}/bin.ntx64/p4api_vs{p4apiVisualStudioEdition}_dyn_vsdebug_openssl3.zip", workingFolder, checksums);
 			ExtractP4apiSDK(p4apiDbgFile, p4apiTargetFolder, $"x64.vs{visualStudioEdition}.dyn.debug");
 	
 			// Download and deploy the release P4API
-			string p4apiRelFile = ModuleInfo.DownloadFileToFolder($"{p4apiUrlRoot}/bin.ntx64/p4api_vs{p4apiVisualStudioEdition}_dyn_openssl1.1.1.zip", workingFolder, checksums);
+			string p4apiRelFile = ModuleInfo.DownloadFileToFolder($"{p4apiUrlRoot}/bin.ntx64/p4api_vs{p4apiVisualStudioEdition}_dyn_openssl3.zip", workingFolder, checksums);
 			ExtractP4apiSDK(p4apiRelFile, p4apiTargetFolder, $"x64.vs{visualStudioEdition}.dyn.release");
 	
 			// Download and deploy the perforce test binaries

--- a/external/P4VFS/P4VFS.Module.cs
+++ b/external/P4VFS/P4VFS.Module.cs
@@ -11,7 +11,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class P4vfsModule : Module
 	{
-		private const string P4VFS_SIGNED_VERSION = "1.27.0.0";
+		private const string P4VFS_SIGNED_VERSION = "1.28.0.0";
 		private const string P4VFS_SIGNED_ARTIFACTS_URL = "https://github.com/microsoft/p4vfs/releases/download";
 
 		public override string Name

--- a/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
+++ b/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
@@ -90,30 +90,30 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core">
-      <Version>1.38.0</Version>
+      <Version>1.41.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Identity">
-      <Version>1.10.4</Version>
+      <Version>1.12.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Security.KeyVault.Secrets">
       <Version>4.6.0</Version>
     </PackageReference>
     <PackageReference Include="Azure.Storage.Blobs">
-      <Version>12.19.1</Version>
+      <Version>12.21.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.9.1</Version>
+      <Version>6.10.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(OpenSSLApiLibDir)\libcrypto-1_1-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(OpenSSLApiLibDir)\libssl-1_1-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OpenSSLApiLibDir)\libcrypto-3-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OpenSSLApiLibDir)\libssl-3-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(P4VFSCoreBuildDir)\$(P4VFSConfiguration)\P4VFS.Core.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(P4VFSCoreBuildDir)\$(P4VFSConfiguration)\P4VFS.Core.pdb" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(PkgNuGet_CommandLine)\tools\nuget.exe" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />

--- a/source/P4VFS.CodeSign/Resource/SignInputStaging.json
+++ b/source/P4VFS.CodeSign/Resource/SignInputStaging.json
@@ -73,11 +73,11 @@
       "SignRequestFiles": [
         {
           "CustomerCorrelationId": "01A7F55F-6CDD-4123-B255-77E6F212CDAD",
-          "SourceLocation": "libcrypto-1_1-x64.dll"
+          "SourceLocation": "libcrypto-3-x64.dll"
         },
         {
           "CustomerCorrelationId": "01A7F55F-6CDD-4123-B255-77E6F212CDAD",
-          "SourceLocation": "libssl-1_1-x64.dll"
+          "SourceLocation": "libssl-3-x64.dll"
         }
       ],
       "SigningInfo": {

--- a/source/P4VFS.CodeSign/Source/EsrpClient.cs
+++ b/source/P4VFS.CodeSign/Source/EsrpClient.cs
@@ -14,7 +14,7 @@ namespace Microsoft.P4VFS.CodeSign
 {
 	public class EsrpClient : ICodeSignClient
 	{
-		private const string _EsrpClientVersion = "1.2.85";
+		private const string _EsrpClientVersion = "1.2.102";
 		private const string _EsrpClientPkgSource = "https://microsoft.pkgs.visualstudio.com/_packaging/ESRP/nuget/v3/index.json";
 
 		public EsrpClient()

--- a/source/P4VFS.Console/P4VFS.Console.csproj
+++ b/source/P4VFS.Console/P4VFS.Console.csproj
@@ -159,8 +159,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(OpenSSLApiLibDir)\libcrypto-1_1-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(OpenSSLApiLibDir)\libssl-1_1-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OpenSSLApiLibDir)\libcrypto-3-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OpenSSLApiLibDir)\libssl-3-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(P4VFSCoreBuildDir)\$(P4VFSConfiguration)\P4VFS.Core.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(P4VFSCoreBuildDir)\$(P4VFSConfiguration)\P4VFS.Core.pdb" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -8,6 +8,7 @@ Version [1.28.0.0]
   down-level compatibility new zeroed allocation API's such as ExAllocatePool2
 * Fixing bug causing some perforce sync errors not to be shown when doing a quite
   single mode sync, such as 'populate', or 'sync -q -m Single'
+* Update to P4API 2024.1 and OpenSSL 3.3.1. UnitTest now uses p4d.exe/p4.exe 2024.1
 
 Version [1.27.1.0]
 * Now also ignoring specdef tag from P4API results, similar to P4API.NET

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -9,6 +9,7 @@ Version [1.28.0.0]
 * Fixing bug causing some perforce sync errors not to be shown when doing a quite
   single mode sync, such as 'populate', or 'sync -q -m Single'
 * Update to P4API 2024.1 and OpenSSL 3.3.1. UnitTest now uses p4d.exe/p4.exe 2024.1
+* Virtual sync details at the start of sync operation now write to StdOut instead of StdErr
 
 Version [1.27.1.0]
 * Now also ignoring specdef tag from P4API results, similar to P4API.NET

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,14 @@
 Microsoft P4VFS Release Notes
 
+Version [1.28.0.0]
+* Addition of 'dehydrate' command as synonym for 'resident -v', for changing existing
+  files from #have to zero-byte placeholder files. Unit tests included.
+* Fixing support for p4vfsflt driver backwards compatibility for Windows Server 2019 and 
+  earlier, including Windows prior to Windows 10 version 2004. This addressed
+  down-level compatibility new zeroed allocation API's such as ExAllocatePool2
+* Fixing bug causing some perforce sync errors not to be shown when doing a quite
+  single mode sync, such as 'populate', or 'sync -q -m Single'
+
 Version [1.27.1.0]
 * Now also ignoring specdef tag from P4API results, similar to P4API.NET
 * The P4VFS install now configures the driver as allowed by Windows DevDrive, and

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -134,11 +134,12 @@ Available commands:
               p4vfs set [SettingName|SubString]
 "},
 
-{"resident,hydrate", @"
+{"resident,hydrate,dehydrate", @"
   resident    Modify current resident status of local files. This can be used
               to change existing files back to virtual state (zero downloaded size),
               or change files to a resident state (full downloaded size).
   hydrate     Synonym for 'resident -r'
+  dehydrate   Synonym for 'resident -v'
 
               p4vfs resident [-r -v -x <csx> -p <reg>] [file ...]
 
@@ -336,6 +337,9 @@ Available commands:
 						break;
 					case "hydrate":
 						status = CommandHydrate(cmdArgs);
+						break;
+					case "dehydrate":
+						status = CommandDehydrate(cmdArgs);
 						break;
 					case "populate":
 						status = CommandPopulate(cmdArgs);
@@ -815,6 +819,11 @@ Available commands:
 		private static bool CommandHydrate(string[] args)
 		{
 			return CommandResident(new[]{"-r"}.Concat(args).ToArray());
+		}
+
+		private static bool CommandDehydrate(string[] args)
+		{
+			return CommandResident(new[]{"-v"}.Concat(args).ToArray());
 		}
 
 		private static bool CommandMonitor(string[] args)

--- a/source/P4VFS.Core/Include/DepotClient.h
+++ b/source/P4VFS.Core/Include/DepotClient.h
@@ -70,7 +70,7 @@ namespace P4 {
 
 		P4VFS_CORE_API LogDevice* Log();
 		P4VFS_CORE_API void Log(LogChannel::Enum channel, const DepotString& text);
-		P4VFS_CORE_API bool IsFaulted() const;
+		P4VFS_CORE_API bool IsFaulted();
 
 		struct Flags { enum Enum
 		{

--- a/source/P4VFS.Core/Include/FileCore.h
+++ b/source/P4VFS.Core/Include/FileCore.h
@@ -361,8 +361,8 @@ namespace FileCore {
 				typedef AString TString;
 				typedef char TChar;
 
-				static char* Literal(char* A, wchar_t* W) { return A; }
-				static char  Literal(char A, wchar_t W) { return A; }
+				static const char* Literal(const char* A, const wchar_t* W) { return A; }
+				static const char  Literal(const char A, const wchar_t W) { return A; }
 			};
 
 			template <> struct Type<wchar_t>
@@ -371,8 +371,8 @@ namespace FileCore {
 				typedef WString TString;
 				typedef wchar_t TChar;
 
-				static wchar_t* Literal(char* A, wchar_t* W) { return W; }
-				static wchar_t  Literal(char A, wchar_t W) { return W; }
+				static const wchar_t* Literal(const char* A, const wchar_t* W) { return W; }
+				static const wchar_t  Literal(const char A, const wchar_t W) { return W; }
 			};
 		};
 

--- a/source/P4VFS.Core/Include/LogDevice.h
+++ b/source/P4VFS.Core/Include/LogDevice.h
@@ -78,15 +78,33 @@ namespace FileCore {
 		}
 
 		template <typename TString>
+		static void Verbose(LogDevice* log, const TString& text) 
+		{ 
+			WriteLine(log, LogChannel::Verbose, text); 
+		}
+
+		template <typename TString>
 		void Info(const TString& text) 
 		{ 
 			WriteLine(LogChannel::Info, text); 
 		}
 
 		template <typename TString>
+		static void Info(LogDevice* log, const TString& text) 
+		{ 
+			WriteLine(log, LogChannel::Info, text); 
+		}
+
+		template <typename TString>
 		void Warning(const TString& text) 
 		{ 
 			WriteLine(LogChannel::Warning, text); 
+		}
+
+		template <typename TString>
+		static void Warning(LogDevice* log, const TString& text) 
+		{ 
+			WriteLine(log, LogChannel::Warning, text); 
 		}
 		
 		template <typename TString>
@@ -96,10 +114,23 @@ namespace FileCore {
 		}
 
 		template <typename TString>
+		static void Error(LogDevice* log, const TString& text) 
+		{ 
+			WriteLine(log, LogChannel::Error, text); 
+		}
+
+		template <typename TString>
 		static void WriteLine(LogDevice* log, LogChannel::Enum channel, const TString& text)
 		{
 			if (log != nullptr)
+			{
 				log->WriteLine(channel, text);
+			}
+		}
+
+		static bool IsFaulted(LogDevice* log)
+		{
+			return log != nullptr && log->IsFaulted();
 		}
 	};
 
@@ -154,6 +185,20 @@ namespace FileCore {
 		virtual bool IsFaulted() override;
 
 		Array<LogDevice*> m_Devices;
+	};
+
+	struct LogDeviceFilter : LogDevice
+	{
+		LogDeviceFilter(LogDevice* device, LogChannel::Enum level = LogChannel::Enum(0));
+
+		void SetLevel(LogChannel::Enum level);
+		LogChannel::Enum GetLevel() const;
+
+		virtual void Write(const LogElement& element) override;
+		virtual bool IsFaulted() override;
+
+		LogDevice* m_InnerDevice;
+		LogChannel::Enum m_Level;
 	};
 
 	class LogSystem : public LogDevice

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -996,15 +996,12 @@ LogDevice* FDepotClient::Log()
 
 void FDepotClient::Log(LogChannel::Enum channel, const DepotString& text)
 {
-	if (m_P4->m_FileContext && m_P4->m_FileContext->m_LogDevice)
-	{
-		m_P4->m_FileContext->m_LogDevice->WriteLine(channel, text);
-	}
+	LogDevice::WriteLine(Log(), channel, text);
 }
 
-bool FDepotClient::IsFaulted() const
+bool FDepotClient::IsFaulted()
 {
-	return m_P4->m_FileContext && m_P4->m_FileContext->m_LogDevice && m_P4->m_FileContext->m_LogDevice->IsFaulted();
+	return LogDevice::IsFaulted(Log());
 }
 
 FDepotClient::Flags::Enum FDepotClient::GetFlags() const 

--- a/source/P4VFS.Core/Source/DepotOperations.cpp
+++ b/source/P4VFS.Core/Source/DepotOperations.cpp
@@ -665,7 +665,7 @@ DepotOperations::Reconfig(
 
 				if (hr != S_OK)
 				{
-					LogDevice::WriteLine(log, LogChannel::Error, StringInfo::Format("Failed to reconfig file '%s' with error [%s]", clientFile.c_str(), CSTR_WTOA(StringInfo::ToString(hr))));
+					LogDevice::Error(log, StringInfo::Format("Failed to reconfig file '%s' with error [%s]", clientFile.c_str(), CSTR_WTOA(StringInfo::ToString(hr))));
 					status = false;
 				}
 			}
@@ -792,9 +792,15 @@ DepotOperations::SyncCommand(
 		return nullptr;
 	}
 
-	if (log == nullptr && (syncFlags & DepotSyncFlags::Quiet) == 0)
+	if (log == nullptr)
 	{
 		log = depotClient->Log();
+	}
+	
+	LogDeviceFilter errorLog(log, LogChannel::Error);
+	if (syncFlags & DepotSyncFlags::Quiet)
+	{
+		log = &errorLog;
 	}
 
 	auto reportError = [&](const DepotString& context) -> void

--- a/source/P4VFS.Core/Source/DepotOperations.cpp
+++ b/source/P4VFS.Core/Source/DepotOperations.cpp
@@ -72,7 +72,7 @@ DepotOperations::SyncVirtual(
 		}
 	}
 
-	depotClient->Log(LogChannel::Warning, StringInfo::Join(DepotStringArray{ "Virtual Sync:", ToString(syncOptions.m_Files), DepotSyncFlags::ToString(syncOptions.m_SyncFlags), DepotFlushType::ToString(syncOptions.m_FlushType), revision->ToString() }, " "));
+	depotClient->Log(LogChannel::Info, StringInfo::Join(DepotStringArray{ "Virtual Sync:", ToString(syncOptions.m_Files), DepotSyncFlags::ToString(syncOptions.m_SyncFlags), DepotFlushType::ToString(syncOptions.m_FlushType), revision->ToString() }, " "));
 	depotClient->Log(LogChannel::Info, StringInfo::Format("Started at [%s] version [%s]", DepotDateTime::Now().ToDisplayString().c_str(), CSTR_WTOA(FileSystem::GetModuleVersion())));
 	if (depotClient->IsFaulted())
 	{
@@ -797,10 +797,10 @@ DepotOperations::SyncCommand(
 		log = depotClient->Log();
 	}
 	
-	LogDeviceFilter errorLog(log, LogChannel::Error);
+	LogDeviceFilter quietLog(log, syncFlags & DepotSyncFlags::Flush ? LogChannel::Error : LogChannel::Warning);
 	if (syncFlags & DepotSyncFlags::Quiet)
 	{
-		log = &errorLog;
+		log = &quietLog;
 	}
 
 	auto reportError = [&](const DepotString& context) -> void

--- a/source/P4VFS.Core/Source/FileCore.cpp
+++ b/source/P4VFS.Core/Source/FileCore.cpp
@@ -744,7 +744,7 @@ WString StringInfo::Escape(const wchar_t* s, EscapeDirection::Enum direction)
 		const Encoding text[] = { {TEXT("\\\""), TEXT("\"")}, {TEXT("\\\\"), TEXT("\\")}, {TEXT("\\n"), TEXT("\n")}, {TEXT("\\r"), TEXT("\r")}, {TEXT("\\t"), TEXT("\t")} };
 		const int32_t src = (direction == EscapeDirection::Encode ? 1 : 0);
 		const int32_t dst = src ^ 1;
-		while (s != TEXT('\0'))
+		while (*s != TEXT('\0'))
 		{
 			size_t i = 0;
 			for (; i < _countof(text); ++i)

--- a/source/P4VFS.Core/Source/LogDevice.cpp
+++ b/source/P4VFS.Core/Source/LogDevice.cpp
@@ -225,6 +225,25 @@ bool LogDeviceAggregate::IsFaulted()
 	return false;
 }
 
+LogDeviceFilter::LogDeviceFilter(LogDevice* device, LogChannel::Enum level) :
+	m_InnerDevice(device),
+	m_Level(level)
+{
+}
+
+void LogDeviceFilter::Write(const LogElement& element)
+{
+	if (m_InnerDevice != nullptr && element.m_Channel >= m_Level)
+	{
+		m_InnerDevice->Write(element);
+	}
+}
+
+bool LogDeviceFilter::IsFaulted()
+{
+	return m_InnerDevice != nullptr ? m_InnerDevice->IsFaulted() : false;
+}
+
 LogSystem::LogSystem() :
 	m_WriteThread(NULL),
 	m_WriteMutex(NULL),

--- a/source/P4VFS.Core/Tests/TestDriver.cpp
+++ b/source/P4VFS.Core/Tests/TestDriver.cpp
@@ -17,7 +17,6 @@ typedef	VOID* PFLT_VOLUME;
 typedef	VOID* PKTRANSACTION;
 typedef	INT	FLT_FILE_NAME_PARSED_FLAGS;
 typedef	INT	FLT_FILE_NAME_OPTIONS;
-typedef ULONG64 POOL_FLAGS;
 typedef	VOID* PACCESS_STATE;
 typedef INT FILE_INFORMATION_CLASS;
 typedef HANDLE PEPROCESS;
@@ -219,6 +218,10 @@ typedef	struct _FILE_STANDARD_INFORMATION_EX {
 	BOOLEAN	MetadataAttribute;
 } FILE_STANDARD_INFORMATION_EX,	*PFILE_STANDARD_INFORMATION_EX;
 
+typedef enum _POOL_TYPE {
+	NonPagedPoolNx = 512,
+} POOL_TYPE;
+
 #define	P4vfsTraceError(...)			__noop
 #define	P4vfsTraceWarning(...)			__noop
 #define	P4vfsTraceInfo(...)				__noop
@@ -280,7 +283,7 @@ std::function<NTSTATUS(PFLT_INSTANCE, PFILE_OBJECT, PVOID, ULONG, FILE_INFORMATI
 std::function<NTSTATUS(PFLT_INSTANCE, PFLT_VOLUME*)> FltGetVolumeFromInstance;
 std::function<NTSTATUS(PFLT_VOLUME, PUNICODE_STRING, PULONG)> FltGetVolumeName;
 
-std::function<PVOID(POOL_FLAGS, SIZE_T, ULONG)> ExAllocatePool2;
+std::function<PVOID(POOL_TYPE, SIZE_T, ULONG)> ExAllocatePoolZero;
 std::function<VOID(PVOID, ULONG)> ExFreePoolWithTag;
 std::function<VOID(PFAST_MUTEX)> ExAcquireFastMutex;
 std::function<VOID(PFAST_MUTEX)> ExReleaseFastMutex;
@@ -430,7 +433,7 @@ static void InternalTestDriverReset(const TestContext& context)
 	FltQueryInformationFile = P4VFS_DEFAULT_FUNCTION_NTSTATUS();
 	FltGetVolumeFromInstance = P4VFS_DEFAULT_FUNCTION_NTSTATUS();
 
-	ExAllocatePool2 = [](POOL_FLAGS, SIZE_T s, ULONG) -> PVOID { return GAlloc(s); };
+	ExAllocatePoolZero = [](POOL_TYPE, SIZE_T s, ULONG) -> PVOID { return GAlloc(s); };
 	ExFreePoolWithTag = [](PVOID p, ULONG) -> VOID { GFree(p); };
 	ExAcquireFastMutex = P4VFS_DEFAULT_ACTION();
 	ExReleaseFastMutex = P4VFS_DEFAULT_ACTION();

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
-#define P4VFS_VER_MINOR					27			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_MINOR					28			// Increment this number whenever the driver changes
+#define P4VFS_VER_BUILD					0			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v

--- a/source/P4VFS.Driver/P4VFS.Driver.vcxproj
+++ b/source/P4VFS.Driver/P4VFS.Driver.vcxproj
@@ -74,7 +74,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>$(P4VFSDriverIncludeDir);$(OutDir)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;P4VFS_KERNEL_MODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;P4VFS_KERNEL_MODE;POOL_NX_OPTIN;POOL_ZERO_DOWN_LEVEL_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4127;4748;4995;4311;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <SupportJustMyCode>false</SupportJustMyCode>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -96,7 +96,7 @@
     </Link>
     <ClCompile>
       <AdditionalIncludeDirectories>$(P4VFSDriverIncludeDir);$(OutDir)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;P4VFS_KERNEL_MODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;P4VFS_KERNEL_MODE;POOL_NX_OPTIN;POOL_ZERO_DOWN_LEVEL_SUPPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4127;4748;4995;4311;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <CompileAs>CompileAsC</CompileAs>

--- a/source/P4VFS.Driver/Source/DriverCore.c
+++ b/source/P4VFS.Driver/Source/DriverCore.c
@@ -139,8 +139,8 @@ P4vfsUserModeExecuteRequest(
 	}
 
 	// Allocate a reply message
-	pReplyMsg = (P4VFS_SERVICE_REPLY*)ExAllocatePool2( 
-											POOL_FLAG_NON_PAGED,
+	pReplyMsg = (P4VFS_SERVICE_REPLY*)ExAllocatePoolZero( 
+											NonPagedPoolNx,
 											sizeof(P4VFS_SERVICE_REPLY),
 											P4VFS_REPLY_MSG_ALLOC_TAG);
 
@@ -238,8 +238,8 @@ P4vfsUserModeResolveFile(
 	const ULONG dataNameOffset = requestMsgSize;
 	requestMsgSize += dataNameSize;
 
-	pRequestMsg = (P4VFS_SERVICE_MSG*)ExAllocatePool2( 
-											POOL_FLAG_NON_PAGED,
+	pRequestMsg = (P4VFS_SERVICE_MSG*)ExAllocatePoolZero( 
+											NonPagedPoolNx,
 											requestMsgSize,
 											P4VFS_SERVICE_MSG_ALLOC_TAG);
 
@@ -555,13 +555,13 @@ P4vfsPushReparseActionInProgress(
 
 		if (pAction == NULL)
 		{
-			pAction = (P4VFS_REPARSE_ACTION*)ExAllocatePool2(
-												POOL_FLAG_NON_PAGED, 
+			pAction = (P4VFS_REPARSE_ACTION*)ExAllocatePoolZero(
+												NonPagedPoolNx, 
 												sizeof(P4VFS_REPARSE_ACTION), 
 												P4VFS_REPARSE_ACTION_ALLOC_TAG);
 			if (pAction == NULL)
 			{ 
-				P4vfsTraceError(Core, L"P4vfsPushReparseActionInProgress: ExAllocatePool2 failed [%wZ]", &actionFileKey); 
+				P4vfsTraceError(Core, L"P4vfsPushReparseActionInProgress: ExAllocatePoolZero failed [%wZ]", &actionFileKey); 
 			}
 			else
 			{
@@ -742,8 +742,8 @@ P4vfsAllocateUnicodeString(
 		return STATUS_INVALID_BUFFER_SIZE;
 	}
 
-	pString->Buffer = (PWCH)ExAllocatePool2(
-								POOL_FLAG_NON_PAGED, 
+	pString->Buffer = (PWCH)ExAllocatePoolZero(
+								NonPagedPoolNx, 
 								pString->MaximumLength, 
 								poolTag);
 

--- a/source/P4VFS.Driver/Source/DriverFilter.c
+++ b/source/P4VFS.Driver/Source/DriverFilter.c
@@ -288,6 +288,9 @@ DriverEntry(
 		goto CLEANUP;
 	}
 
+	// Default to NonPagedPoolNx for non paged pool allocations where supported.
+	ExInitializeDriverRuntime(DrvRtPoolNxOptIn);
+
 	// Register with FltMgr to tell it our callback routines
 	status = FltRegisterFilter(pDriverObject, &kDriverFilterRegistration, &g_FltContext.pFilter);
 	if (!NT_SUCCESS(status)) 
@@ -549,8 +552,8 @@ P4vfsServicePortConnect(
 		goto CLEANUP;
 	}
 
-	pConnectionHandle = (P4VFS_SERVICE_PORT_CONNECTION_HANDLE*)ExAllocatePool2( 
-																	POOL_FLAG_NON_PAGED,
+	pConnectionHandle = (P4VFS_SERVICE_PORT_CONNECTION_HANDLE*)ExAllocatePoolZero( 
+																	NonPagedPoolNx,
 																	sizeof(P4VFS_SERVICE_PORT_CONNECTION_HANDLE),
 																	P4VFS_SERVICE_PORT_HANDLE_ALLOC_TAG);
 
@@ -657,8 +660,8 @@ P4vfsControlPortConnect(
 		goto CLEANUP;
 	}
 
-	pConnectionHandle = (P4VFS_CONTROL_PORT_CONNECTION_HANDLE*)ExAllocatePool2( 
-																	POOL_FLAG_NON_PAGED,
+	pConnectionHandle = (P4VFS_CONTROL_PORT_CONNECTION_HANDLE*)ExAllocatePoolZero( 
+																	NonPagedPoolNx,
 																	sizeof(P4VFS_CONTROL_PORT_CONNECTION_HANDLE),
 																	P4VFS_CONTROL_PORT_HANDLE_ALLOC_TAG);
 

--- a/source/P4VFS.External/P4VFS.External.csproj
+++ b/source/P4VFS.External/P4VFS.External.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.CommandLine" GeneratePathProperty="true">
-      <Version>6.9.1</Version>
+      <Version>6.10.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/P4VFS.External/Source/Module.cs
+++ b/source/P4VFS.External/Source/Module.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.P4VFS.Extensions.Utilities;
@@ -174,9 +174,15 @@ namespace Microsoft.P4VFS.External
 			
 			Trace.TraceInformation("Downloading {0} -> {1}", url, filePath);
 			Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-			using (System.Net.WebClient request = new System.Net.WebClient())
+			using (HttpClient client = new HttpClient())
 			{
-				request.DownloadFile(url, filePath);
+				using (HttpResponseMessage response = client.GetAsync(url).Result)
+				{
+					using (FileStream fileStream = new FileStream(filePath, FileMode.CreateNew))
+					{
+						response.Content.CopyToAsync(fileStream).Wait();
+					}
+				}
 			}
 
 			if (File.Exists(filePath) == false)

--- a/source/P4VFS.Monitor/P4VFS.Monitor.csproj
+++ b/source/P4VFS.Monitor/P4VFS.Monitor.csproj
@@ -107,8 +107,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy SourceFiles="$(OpenSSLApiLibDir)\libcrypto-1_1-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(OpenSSLApiLibDir)\libssl-1_1-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OpenSSLApiLibDir)\libcrypto-3-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(OpenSSLApiLibDir)\libssl-3-x64.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(P4VFSCoreBuildDir)\$(P4VFSConfiguration)\P4VFS.Core.dll" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(P4VFSCoreBuildDir)\$(P4VFSConfiguration)\P4VFS.Core.pdb" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/source/P4VFS.Setup/P4VFS.Setup.csproj
+++ b/source/P4VFS.Setup/P4VFS.Setup.csproj
@@ -159,8 +159,8 @@
     <InstallResource Include="$(P4VFSBuildDir)\P4VFS.CoreInterop\$(P4VFSConfiguration)\P4VFS.CoreInterop.dll" Visible="false" />
     <InstallResource Include="$(P4VFSBuildDir)\P4VFS.UnitTest\$(Configuration)\P4VFS.UnitTest.dll" Visible="false" />
     <InstallResource Include="$(P4VFSBuildDir)\P4VFS.UnitTest\$(Configuration)\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll" Visible="false" />
-    <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Console\$(Configuration)\libcrypto-1_1-x64.dll" Visible="false" />
-    <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Console\$(Configuration)\libssl-1_1-x64.dll" Visible="false" />
+    <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Console\$(Configuration)\libcrypto-3-x64.dll" Visible="false" />
+    <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Console\$(Configuration)\libssl-3-x64.dll" Visible="false" />
     <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Console\$(Configuration)\p4vfs.exe" Visible="false" />
     <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Console\$(Configuration)\P4VFS.Notes.txt" Visible="false" />
     <InstallResource Include="$(P4VFSBuildDir)\P4VFS.Monitor\$(P4VFSConfiguration)\P4VFS.Monitor.exe" Visible="false" />

--- a/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
@@ -1507,7 +1507,7 @@ namespace Microsoft.P4VFS.UnitTest
 					DepotSyncResult syncResult = depotClient.Sync("//...", null, DepotSyncFlags.Flush|DepotSyncFlags.Quiet);
 					Assert(syncResult != null && syncResult.Modifications != null);
 					Assert((syncResult.Status == DepotSyncStatus.Success && syncResult.Modifications.Length > clientFileCount) || 
-						   (syncResult.Status == DepotSyncStatus.Warning && syncResult.Modifications.Length == 1 && syncResult.Modifications[0].SyncActionType == DepotSyncActionType.UpToDate));
+						   (syncResult.Status == DepotSyncStatus.Success && syncResult.Modifications.Length == 1 && syncResult.Modifications[0].SyncActionType == DepotSyncActionType.UpToDate));
 
 					syncResult = depotClient.Sync("//...");
 					Assert(syncResult?.Status == DepotSyncStatus.Success);

--- a/source/P4VFS.UnitTest/Source/UnitTestInstall.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestInstall.cs
@@ -75,6 +75,7 @@ namespace Microsoft.P4VFS.UnitTest
 				string[] allowedLocalSignErrors = new string[]
 				{
 					@"SignTool Error: A certificate chain processed, but terminated in a root\n(.*\n)*\s+certificate which is not trusted by the trust provider.",
+					@"SignTool Error: Signing Cert does not chain to a Microsoft Root Cert.",
 				};
 				Func<string, bool> isAllowedLocalSignError = (string text) => allowedLocalSignErrors.Any(e => Regex.IsMatch(text, e, RegexOptions.IgnoreCase|RegexOptions.Multiline));
 				Func<string, bool> isAllowedSignError = (string text) => !production && isAllowedLocalSignError(text);

--- a/source/P4VFS.UnitTest/Source/UnitTestWorkflow.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestWorkflow.cs
@@ -376,7 +376,8 @@ namespace Microsoft.P4VFS.UnitTest
 		{
 			var AssertFileSyncStatus = new Action<string,string,bool>((string depotSpec, string syncOption, bool valid) =>
 			{
-				int exitCode = ProcessInfo.ExecuteWait(P4vfsExe, String.Format("{0} sync {1} {2}", ClientConfig, syncOption, depotSpec), echo:true, log:true);
+				ProcessInfo.ExecuteResultOutput syncOutput = ProcessInfo.ExecuteWaitOutput(P4vfsExe, String.Format("{0} sync {1} {2}", ClientConfig, syncOption, depotSpec), echo:true, log:true);
+				int exitCode = syncOutput.ExitCode == 0 && syncOutput.HasStdErr == false ? 0 : 1;
 				Assert((valid == true && exitCode == 0) || (valid == false && exitCode != 0));
 				ProcessInfo.ExecuteResultOutput flushOutput = ProcessInfo.ExecuteWaitOutput(P4Exe, String.Format("{0} flush -f {1}", ClientConfig, depotSpec), echo:true);
 				exitCode = (exitCode == 0 && flushOutput.HasStdErr == false) ? 0 : 1;

--- a/source/P4VFS.UnitTest/Source/UnitTestWorkflow.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestWorkflow.cs
@@ -263,6 +263,13 @@ namespace Microsoft.P4VFS.UnitTest
 					Assert(File.Exists(filePath));
 					Assert(IsPlaceholderFile(filePath) != Regex.IsMatch(filePath, @"(\.cs|\.xml)$", RegexOptions.IgnoreCase));
 				}
+
+				Assert(ProcessInfo.ExecuteWait(P4vfsExe, String.Format("{0} dehydrate \"{1}\\...\"", ClientConfig, directory), echo:true, log:true) == 0);
+				foreach (string filePath in directoryFiles)
+				{
+					Assert(File.Exists(filePath));
+					Assert(IsPlaceholderFile(filePath));
+				}
 			}
 		}}
 

--- a/source/P4VFS.props
+++ b/source/P4VFS.props
@@ -65,7 +65,7 @@
     <P4VFSUnitTestBuildDir>$(P4VFSBuildDir)/$(P4VFSUnitTestName)</P4VFSUnitTestBuildDir>
 
     <!-- Perforce API -->
-    <PerforceApiVersion>2023.2</PerforceApiVersion>
+    <PerforceApiVersion>2024.1</PerforceApiVersion>
     <PerforceApiConfiguration>$(P4VFSConfiguration)</PerforceApiConfiguration>
     <PerforceApiDir>$(P4VFSExternalDir)/P4API/$(PerforceApiVersion)</PerforceApiDir>
     <PerforceApiIncludeDir>$(PerforceApiDir)/include</PerforceApiIncludeDir>
@@ -73,13 +73,12 @@
     <PerforceApiLibFiles>libclient.lib;libp4api.lib;libp4script.lib;libp4script_c.lib;libp4script_curl.lib;libp4script_sqlite.lib;librpc.lib;libsupp.lib</PerforceApiLibFiles>
 
     <!-- OpenSSL -->
-    <OpenSSLApiVersion>1.1.1v</OpenSSLApiVersion>
+    <OpenSSLApiVersion>3.3.1</OpenSSLApiVersion>
     <OpenSSLApiConfiguration>$(P4VFSConfiguration)</OpenSSLApiConfiguration>
     <OpenSSLApiDir>$(P4VFSExternalDir)/OpenSSL/$(OpenSSLApiVersion)</OpenSSLApiDir>
     <OpenSSLApiIncludeDir>$(OpenSSLApiDir)/include</OpenSSLApiIncludeDir>
     <OpenSSLApiLibDir>$(OpenSSLApiDir)/lib/x64.vs$(P4VFSVisualStudioEdition).dyn.$(OpenSSLApiConfiguration)</OpenSSLApiLibDir>
     <OpenSSLApiLibFiles>libcrypto.lib;libssl.lib</OpenSSLApiLibFiles>
-    <OpenSSLApiBinFiles>libcrypto-1_1-x64.dll;libssl-1_1-x64.dll</OpenSSLApiBinFiles>
 
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Version [1.28.0.0]
* Addition of 'dehydrate' command as synonym for 'resident -v', for changing existing
  files from #have to zero-byte placeholder files. Unit tests included.
* Fixing support for p4vfsflt driver backwards compatibility for Windows Server 2019 and 
  earlier, including Windows prior to Windows 10 version 2004. This addressed
  down-level compatibility new zeroed allocation API's such as ExAllocatePool2
* Fixing bug causing some perforce sync errors not to be shown when doing a quite
  single mode sync, such as 'populate', or 'sync -q -m Single'
* Update to P4API 2024.1 and OpenSSL 3.3.1. UnitTest now uses p4d.exe/p4.exe 2024.1
* Virtual sync details at the start of sync operation now write to StdOut instead of StdErr