### PR TITLE
Fixing support for specifying a value for P4TICKETS from within a P4CONFIG file

### DIFF
--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,11 @@
 Microsoft P4VFS Release Notes
 
+Version [1.28.2.0]
+* Fixing support for specifying a value for P4TICKETS from within a P4CONFIG file,
+  and correctly used from working directory of p4vfs.exe, or placeholder file folder
+  during service hydration. Service requires P4CONFIG set in system environment or
+  system registry.
+
 Version [1.28.1.0]
 * Fixing possible memory leak during sync operation while accumulating logging 
   elements for statistics

--- a/source/P4VFS.Core/Include/DepotClient.h
+++ b/source/P4VFS.Core/Include/DepotClient.h
@@ -53,6 +53,7 @@ namespace P4 {
 		P4VFS_CORE_API DepotString GetTrustFilePath() const;
 		P4VFS_CORE_API DepotString GetClientOwnerUserName(const DepotString& clientName, const DepotString& portName);
 		P4VFS_CORE_API DepotString GetHostName() const;
+		P4VFS_CORE_API DepotString GetConfigEnv(const char* envVarName) const;
 		P4VFS_CORE_API const DepotConfig& Config() const;
 
 		P4VFS_CORE_API void Run(const DepotCommand& cmd, FDepotResult& result);

--- a/source/P4VFS.Core/Source/FileSystem.cpp
+++ b/source/P4VFS.Core/Source/FileSystem.cpp
@@ -200,6 +200,7 @@ ResolveFileResidency(
 	config.m_Port = P4::DepotOperations::ResolveDepotServerName(StringInfo::ToAnsi(populateInfo->depotServer.c_str()));
 	config.m_User = StringInfo::ToAnsi(populateInfo->depotUser.c_str());
 	config.m_Client = StringInfo::ToAnsi(populateInfo->depotClient.c_str());
+	config.m_Directory = StringInfo::ToAnsi(FileInfo::FolderPath(filePath));
 	const P4::DepotConfig& configKey = config;
 
 	// Make sure we go through all existing clients and a new one before giving up

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -4,7 +4,7 @@
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					28			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_BUILD					2			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v

--- a/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
@@ -1477,14 +1477,15 @@ namespace Microsoft.P4VFS.UnitTest
 					Assert(ProcessInfo.ExecuteWaitOutput(P4vfsExe, "info", directory:subFolder, echo:true, log:true).Lines.Contains("P4 UserName: p4vfstest"));
 					// Override P4TICKETS from P4CONFIG
 					string configTicketsFile = Path.Combine(subFolder, "tix.txt");
-					Assert(File.Exists(configTicketsFile) == false);
+					AssertLambda(() => FileUtilities.DeleteFile(configTicketsFile));
 					AssertLambda(() => File.WriteAllLines(Path.Combine(rootFolder, configFileName), configFileLines.Append($"P4TICKETS={configTicketsFile}").ToArray()));
 					Assert(depotClient.Connect(directoryPath:rootFolder) == false);
+					Assert(File.Exists(configTicketsFile) && FileUtilities.GetFileLength(configTicketsFile) == 0);
 					ProcessInfo.ExecuteResultOutput xr = ProcessInfo.ExecuteWaitOutput(P4Exe, "depots", directory:rootFolder, echo:true);
 					Assert(xr.ExitCode != 0 && xr.Data.Any(s => s.Text.Contains("Perforce password (P4PASSWD) invalid or unset.")));
 					Assert(depotClient.Connect(directoryPath:rootFolder, depotPasswd:UnitTestServer.GetUserP4Passwd(_P4User)));
 					Assert(depotClient.Depots().HasError == false);
-					Assert(File.Exists(configTicketsFile));
+					Assert(File.Exists(configTicketsFile) && FileUtilities.GetFileLength(configTicketsFile) > 0);
 				}}
 			};
 


### PR DESCRIPTION
Version [1.28.2.0]
* Fixing support for specifying a value for P4TICKETS from within a P4CONFIG file,
  and correctly used from working directory of p4vfs.exe, or placeholder file folder
  during service hydration. Service requires P4CONFIG set in system environment or
  system registry.