### PR TITLE
1.29.1.0

### DIFF
--- a/external/OpenSSL/OpenSSL.Module.cs
+++ b/external/OpenSSL/OpenSSL.Module.cs
@@ -12,7 +12,7 @@ namespace Microsoft.P4VFS.External
 {
 	public class OpensslModule : Module
 	{
-		private const string OPENSSL_VERSION = "3.3.1";
+		private const string OPENSSL_VERSION = "3.3.3";
 		private const string PERL_PACKAGE_NAME = "StrawberryPerl";
 		private const string PERL_VERSION = "5.28.0.1";
 
@@ -75,7 +75,7 @@ namespace Microsoft.P4VFS.External
 				$"@ECHO ON",
 				$"CALL \"{vcvarsScriptPath}\"",
 				$"CD /D \"{opensslArchiveFolder}\"",
-				$"\"{perlExe}\" Configure VC-WIN64A no-asm no-tests \"--prefix={opensslConfigurationFolder}\" \"--openssldir={opensslConfigurationFolder}-ssl\" --{configuration}",
+				$"\"{perlExe}\" Configure VC-WIN64A no-asm no-apps no-tests \"--prefix={opensslConfigurationFolder}\" \"--openssldir={opensslConfigurationFolder}-ssl\" --{configuration}",
 				$"IF %ERRORLEVEL% NEQ 0 EXIT /B 1",
 				$"nmake clean",
 				$"IF %ERRORLEVEL% NEQ 0 EXIT /B 1",
@@ -122,10 +122,10 @@ namespace Microsoft.P4VFS.External
 			string opensslArchiveUrl = String.Format("https://www.openssl.org/source/openssl-{0}.tar.gz", OPENSSL_VERSION);
 			string opensslTargetFolder = String.Format("{0}\\{1}", opensslModuleFolder, OPENSSL_VERSION);
 			string workingFolder = String.Format("{0}\\Temp", opensslModuleFolder);
-    
+
 			ShellUtilities.RemoveDirectoryRecursive(opensslTargetFolder);
 			ShellUtilities.RemoveDirectoryRecursive(workingFolder);
-        
+
 			// Download the checksums file
 			string checksumFilePath = ModuleInfo.DownloadFileToFolder(String.Format("{0}.sha256", opensslArchiveUrl), workingFolder);
 			Dictionary<string, string> checksums = ModuleInfo.LoadChecksumFile(checksumFilePath);
@@ -136,7 +136,7 @@ namespace Microsoft.P4VFS.External
 
 			// Build and deploy the release Openssl library
 			BuildOpensslLibrary(opensslArchiveFolder, opensslTargetFolder, "release");
-    
+
 			// Build and deploy the debug Openssl library
 			BuildOpensslLibrary(opensslArchiveFolder, opensslTargetFolder, "debug");
 

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -7,6 +7,13 @@ Version [1.29.1.0]
   from file hydration were suppressed. This could even prevent windows explorer from
   showing offline attribute (icon) change without having to refresh. This fix now 
   allows one attribute change notification when hydration is complete.
+* Addition of common Windows Defender process names to default ExcludedProcessNames, 
+  instead of having to rely on a custom local configuration to exclude these. Recent
+  WD signatures have been aggressively ignoring Offline attribute and sniffing "larger"
+  file-types (FBX,MA,SPP) making this almost essential.
+* Addition of `-a` to `print` command used for file hydration. This can be a significant 
+  perforce server side optimization allowing lockless reads when db.peeking=2 or 3.
+  https://portal.perforce.com/s/article/3839
 
 Version [1.29.0.0]
 * Fixing virtual file hydration to be excluded from system directory notifications.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -14,6 +14,8 @@ Version [1.29.1.0]
 * Addition of `-a` to `print` command used for file hydration. This can be a significant 
   perforce server side optimization allowing lockless reads when db.peeking=2 or 3.
   https://portal.perforce.com/s/article/3839
+* Updating to OpenSSL from 3.3.1 to 3.3.3. Now building with `no-apps` to which very 
+  slightly reduces build time
 
 Version [1.29.0.0]
 * Fixing virtual file hydration to be excluded from system directory notifications.

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,13 @@
 Microsoft P4VFS Release Notes
 
+Version [1.29.1.0]
+* Fixing bug where log output would not be written to the local log file if remote
+  logging was enabled and writting to the remote log file had failed.
+* Fixing undesirable behavior in 1.29.0.0 where all attribute change directory notifications
+  from file hydration were suppressed. This could even prevent windows explorer from
+  showing offline attribute (icon) change without having to refresh. This fix now 
+  allows one attribute change notification when hydration is complete.
+
 Version [1.29.0.0]
 * Fixing virtual file hydration to be excluded from system directory notifications.
   This avoids unecessary FILE_NOTIFY_INFORMATION or DirectoryWatcher events indicating

--- a/source/P4VFS.Core/Include/SettingManager.h
+++ b/source/P4VFS.Core/Include/SettingManager.h
@@ -25,7 +25,7 @@ namespace FileCore {
 		_N( String,   SyncResidentPattern,             L"" ) \
 		_N( bool,     Unattended,                      false ) \
 		_N( String,   Verbosity,                       CSTR_ATOW(FileCore::LogChannel::ToString(FileCore::LogChannel::Info)) ) \
-		_N( String,   ExcludedProcessNames,            L"" ) \
+		_N( String,   ExcludedProcessNames,            L"MsSense.exe;MsMpEng.exe;SenseCE.exe;SenseIR.exe;SearchProtocolHost.exe" ) \
 		_N( int32_t,  CreateFileRetryCount,            8 ) \
 		_N( int32_t,  CreateFileRetryWaitMs,           250 ) \
 		_N( int32_t,  PoolDefaultNumberOfThreads,      8 ) \

--- a/source/P4VFS.Core/Source/FileOperations.cpp
+++ b/source/P4VFS.Core/Source/FileOperations.cpp
@@ -1184,13 +1184,14 @@ PopulateFileByStream(
 		return hr;
 	}
 
-	hr = SetFileAttributesOnHandle(dstFile.Handle(), dstFileAttributes & ~(FILE_ATTRIBUTE_OFFLINE));
-	if (FAILED(hr))
+	dstFile.Close();
+
+	if (!SetFileAttributes(fileToPopulate.c_str(), dstFileAttributes & ~(FILE_ATTRIBUTE_OFFLINE)))
 	{
+		hr = HRESULT_FROM_WIN32(GetLastError());
 		return hr;
 	}
 
-	dstFile.Close();
 	return S_OK;
 }
 

--- a/source/P4VFS.Core/Source/FileSystem.cpp
+++ b/source/P4VFS.Core/Source/FileSystem.cpp
@@ -37,7 +37,7 @@ public:
 	HRESULT Read(HANDLE hWriteHandle, UINT64* bytesWritten) override
 	{
 		P4::FDepotResultPrintHandle printResult(hWriteHandle);
-		m_DepotClient->Run(P4::DepotCommand("print", P4::DepotStringArray{m_DepotFileSpec}), printResult);
+		m_DepotClient->Run(P4::DepotCommand("print", P4::DepotStringArray{"-a",m_DepotFileSpec}), printResult);
 		if (printResult.HasError())
 		{
 			m_DepotClient->Log(LogChannel::Error, StringInfo::Format("DepotPrintFileStream failed '%s' with error [%s]", m_DepotFileSpec.c_str(), printResult.GetError().c_str()));
@@ -68,7 +68,7 @@ MakeFileResident(
 		return E_POINTER;
 	}
 
-	const String fileSpec = StringInfo::Format(L"%s#%u", populateInfo->depotPath.c_str(), uint32_t(populateInfo->fileRevision));
+	const String fileSpec = StringInfo::Format(L"%s#=%u", populateInfo->depotPath.c_str(), uint32_t(populateInfo->fileRevision));
 	const FilePopulateMethod::Enum populateMethod = FilePopulateMethod::FromString(StringInfo::ToAnsi(SettingManager::StaticInstance().PopulateMethod.GetValue()));
 	
 	switch (populateMethod)
@@ -88,7 +88,7 @@ MakeFileResident(
 				return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
 			}
 
-			P4::DepotResult print = depotClient.Run("print", P4::DepotStringArray{"-o", StringInfo::ToAnsi(tempPrintFile.GetFilePath()), StringInfo::ToAnsi(fileSpec)});
+			P4::DepotResult print = depotClient.Run("print", P4::DepotStringArray{"-a","-o", StringInfo::ToAnsi(tempPrintFile.GetFilePath()), StringInfo::ToAnsi(fileSpec)});
 			if (print.get() == nullptr || print->HasError())
 			{
 				depotClient.Log(LogChannel::Error, StringInfo::Format("MakeFileResident '%s' failed print tempfile '%s' for PopulateFile by %s", CSTR_WTOA(fileSpec), CSTR_WTOA(tempPrintFile.GetFilePath()), populateMethodName));

--- a/source/P4VFS.Core/Source/LogDevice.cpp
+++ b/source/P4VFS.Core/Source/LogDevice.cpp
@@ -143,13 +143,11 @@ void LogDeviceFile::WriteInternal(time_t time, LogChannel::Enum channel, const S
 
 		if (m_Impersonate.get())
 		{
-			if (FileOperations::ImpersonateFileAppend(ExpandVariables(m_RemoteFilePath).c_str(), line.c_str(), m_Impersonate.get()))
-				return;
+			FileOperations::ImpersonateFileAppend(ExpandVariables(m_RemoteFilePath).c_str(), line.c_str(), m_Impersonate.get());
 		}
 		else
 		{
-			if (FileOperations::FileAppend(ExpandVariables(m_RemoteFilePath).c_str(), line.c_str()))
-				return;
+			FileOperations::FileAppend(ExpandVariables(m_RemoteFilePath).c_str(), line.c_str());
 		}
 	}
 

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -4,7 +4,7 @@
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					29			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					0			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v

--- a/source/P4VFS.External/Source/Module.cs
+++ b/source/P4VFS.External/Source/Module.cs
@@ -129,7 +129,7 @@ namespace Microsoft.P4VFS.External
 			Dictionary<string, string> checksums = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 			foreach (string line in File.ReadAllLines(checksumFilePath))
 			{
-				Match m = Regex.Match(line, @"^\s*(?<sum>[0-9a-f]+)\s+\*(?<name>\S+)\s*$", RegexOptions.IgnoreCase);
+				Match m = Regex.Match(line, @"^\s*(?<sum>[0-9a-f]+)\s+\*?(?<name>\S+)\s*$", RegexOptions.IgnoreCase);
 				if (m.Success)
 				{
 					checksums[m.Groups["name"].Value] = m.Groups["sum"].Value;

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -239,11 +239,11 @@ namespace Microsoft.P4VFS.UnitTest
 			{ 
 				return String.Join(";", new[]
 				{
-					"SearchProtocolHost.exe",
 					"MsSense.exe",
 					"MsMpEng.exe",
 					"SenseCE.exe",
 					"SenseIR.exe",
+					"SearchProtocolHost.exe",
 				});
 			}
 		}
@@ -340,7 +340,7 @@ namespace Microsoft.P4VFS.UnitTest
 
 			Extensions.SocketModel.SocketModelClient service = new Extensions.SocketModel.SocketModelClient(); 
 			Assert(service.GarbageCollect());
-			Assert(service.SetServiceSetting(nameof(SettingManager.ExcludedProcessNames), SettingNode.FromString(ExcludedProcessNames)));
+			Assert(service.GetServiceSetting(nameof(SettingManager.ExcludedProcessNames)).ToString() == ExcludedProcessNames);
 		}
 
 		public void ServiceRestart()

--- a/source/P4VFS.UnitTest/Source/UnitTestServer.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestServer.cs
@@ -55,6 +55,7 @@ namespace Microsoft.P4VFS.UnitTest
 
 			string[] serverConfigVariables = new[] {
 				"auth.sso.allow.passwd=1",
+				"db.peeking=3",
 				"dm.user.noautocreate=2", 
 				"dm.user.resetpassword=0",
 				"lbr.autocompress=1",

--- a/source/P4VFS.props
+++ b/source/P4VFS.props
@@ -73,7 +73,7 @@
     <PerforceApiLibFiles>libclient.lib;libp4api.lib;libp4script.lib;libp4script_c.lib;libp4script_curl.lib;libp4script_sqlite.lib;librpc.lib;libsupp.lib</PerforceApiLibFiles>
 
     <!-- OpenSSL -->
-    <OpenSSLApiVersion>3.3.1</OpenSSLApiVersion>
+    <OpenSSLApiVersion>3.3.3</OpenSSLApiVersion>
     <OpenSSLApiConfiguration>$(P4VFSConfiguration)</OpenSSLApiConfiguration>
     <OpenSSLApiDir>$(P4VFSExternalDir)/OpenSSL/$(OpenSSLApiVersion)</OpenSSLApiDir>
     <OpenSSLApiIncludeDir>$(OpenSSLApiDir)/include</OpenSSLApiIncludeDir>


### PR DESCRIPTION
Version [1.29.1.0]
* Fixing bug where log output would not be written to the local log file if remote
  logging was enabled and writting to the remote log file had failed.
* Fixing undesirable behavior in 1.29.0.0 where all attribute change directory notifications
  from file hydration were suppressed. This could even prevent windows explorer from
  showing offline attribute (icon) change without having to refresh. This fix now 
  allows one attribute change notification when hydration is complete.
* Addition of common Windows Defender process names to default ExcludedProcessNames, 
  instead of having to rely on a custom local configuration to exclude these. Recent
  WD signatures have been aggressively ignoring Offline attribute and sniffing "larger"
  file-types (FBX,MA,SPP) making this almost essential.
* Addition of `-a` to `print` command used for file hydration. This can be a significant 
  perforce server side optimization allowing lockless reads when db.peeking=2 or 3.
  https://portal.perforce.com/s/article/3839
* Updating to OpenSSL from 3.3.1 to 3.3.3. Now building with `no-apps` to which very 
  slightly reduces build time