### PR TITLE
Certificate auth for Hardware Development Center

### DIFF
--- a/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
+++ b/source/P4VFS.CodeSign/P4VFS.CodeSign.csproj
@@ -101,6 +101,12 @@
     <PackageReference Include="Azure.Storage.Blobs">
       <Version>12.21.1</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens">
+      <Version>8.7.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens">
+      <Version>8.7.0</Version>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>
     </PackageReference>

--- a/source/P4VFS.CodeSign/Resource/SignInputHardwareLabKit.json
+++ b/source/P4VFS.CodeSign/Resource/SignInputHardwareLabKit.json
@@ -39,8 +39,6 @@
             ],
             "DevCenterSign": {
               "TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-              "KeyVaultUri": "https://gfwlcss-kv.vault.azure.net",
-              "SecretName": "gfwlcss-app-reg-secret",
               "ServiceUri": "https://manage.devcenter.microsoft.com",
               "TokenEndpoint": "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/token",
               "Scope": "https://manage.devcenter.microsoft.com",
@@ -69,6 +67,7 @@
               "HLK": {
                 "AgentUsername": "HLKAdminUser",
                 "AgentSecretName": "gfwlcss-hlkadminuser-password",
+                "AgentKeyVaultUri": "https://gfwlcss-kv.vault.azure.net",
                 "ProjectName": "P4VFS",
                 "PoolName": "P4VFS Test",
                 "Controllers": [

--- a/source/P4VFS.CodeSign/Source/HardwareLabKit.cs
+++ b/source/P4VFS.CodeSign/Source/HardwareLabKit.cs
@@ -156,6 +156,7 @@ namespace Microsoft.P4VFS.CodeSign
 		public string AgentUsername { get; set; }
 		public string AgentPassword { get; set; }
 		public string AgentSecretName { get; set; }
+		public string AgentKeyVaultUri { get; set; }
 		public string ProjectName { get; set; }
 		public string PoolName { get; set; }
 	}

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,10 @@
 Microsoft P4VFS Release Notes
 
+Version [1.29.2.0]
+* Replacing authentication for public driver codesign from Hardware Development 
+  Center from deprecated client secret to x509 certifcate. This is similar to 
+  the PRSS codesign authentication and is generally more secure.
+
 Version [1.29.1.0]
 * Fixing bug where log output would not be written to the local log file if remote
   logging was enabled and writting to the remote log file had failed.

--- a/source/P4VFS.Driver/Include/DriverVersion.h
+++ b/source/P4VFS.Driver/Include/DriverVersion.h
@@ -4,7 +4,7 @@
 
 #define P4VFS_VER_MAJOR					1			// Increment this number almost never
 #define P4VFS_VER_MINOR					29			// Increment this number whenever the driver changes
-#define P4VFS_VER_BUILD					1			// Increment this number when a major user mode change has been made
+#define P4VFS_VER_BUILD					2			// Increment this number when a major user mode change has been made
 #define P4VFS_VER_REVISION				0			// Increment this number when we rebuild with any change
 
 #define P4VFS_VER_STRINGIZE_EX(v)		L#v


### PR DESCRIPTION
* Replacing authentication for public driver codesign from Hardware Development 
  Center from deprecated client secret to x509 certificate. This is similar to 
  the PRSS codesign authentication and is generally more secure.