### PR TITLE
Fix a race between sending data and closing the service client port

### DIFF
--- a/source/P4VFS.Driver/Source/DriverFilter.c
+++ b/source/P4VFS.Driver/Source/DriverFilter.c
@@ -608,19 +608,10 @@ P4vfsServicePortDisconnect(
 		goto CLEANUP; 
 	}
 
+	P4vfsTraceInfo(Filter, L"P4vfsServicePortDisconnect: Closed active connection [%p]", g_FltContext.pServiceClientPort);
+	FltCloseClientPort(g_FltContext.pFilter, &g_FltContext.pServiceClientPort);
+
 	pConnectionHandle = (P4VFS_SERVICE_PORT_CONNECTION_HANDLE*)pConnectionCookie;
-	if (pConnectionHandle->pClientPort != NULL)
-	{
-		// If this connection handle is our exclusive active pServiceClientPort, clear this value as we close the handle
-		if (pConnectionHandle->pClientPort == g_FltContext.pServiceClientPort)
-		{
-			P4vfsTraceInfo(Filter, L"P4vfsServicePortDisconnect: Closed active connection [%p]", g_FltContext.pServiceClientPort);
-			g_FltContext.pServiceClientPort = NULL;
-		}
-
-		FltCloseClientPort(g_FltContext.pFilter, &pConnectionHandle->pClientPort);
-	}
-
 	if (pConnectionHandle->hUserProcess != NULL)
 	{
 		ZwClose(pConnectionHandle->hUserProcess);


### PR DESCRIPTION
According to documentation, FltCloseClientPort and FltSendMessage are synchronized by both receiving a pointer to the same location that holds the opaque port handle.

This fix passes the global client port to both function calls.

Please note that I removed the unnecessary comparison between the context and the global port. If the connection was successful, the global service client port and the client port in the provided context both have to be the same.