### PR TITLE
SSO login from URL now uses p4vfs console

### DIFF
--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -1,5 +1,15 @@
 Microsoft P4VFS Release Notes
 
+Version [1.29.3.0]
+* Perforce SSO login from URL now uses impersonated p4vfs login command and ShellExecute 
+  instead of using cmd.exe. This fix rare case lingering cmd.exe processes from failed launch 
+  of the browser when there's no desktop session. This also prevents cmd.exe 
+  with inherited handles, including TCP ports, from remaining open after service
+  is stopped and possibly causing failed port reopening after reinstall.
+* Added option 'login -u <url>' for handling login challenge in web browser
+* Added option 'login -t <seconds>' for timeout of login command before self
+  termination. This offers safety from possible lingering interactive prompts.
+
 Version [1.29.2.0]
 * Replacing authentication for public driver codesign from Hardware Development 
   Center from deprecated client secret to x509 certificate. This is similar to 

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -2,13 +2,15 @@ Microsoft P4VFS Release Notes
 
 Version [1.29.3.0]
 * Perforce SSO login from URL now uses impersonated p4vfs login command and ShellExecute 
-  instead of using cmd.exe. This fix rare case lingering cmd.exe processes from failed launch 
-  of the browser when there's no desktop session. This also prevents cmd.exe 
+  instead of using cmd.exe. This fixes rare case lingering cmd.exe processes from failed 
+  launch of the browser when there's no desktop session. This also prevents cmd.exe 
   with inherited handles, including TCP ports, from remaining open after service
   is stopped and possibly causing failed port reopening after reinstall.
 * Added option 'login -u <url>' for handling login challenge in web browser
 * Added option 'login -t <seconds>' for timeout of login command before self
   termination. This offers safety from possible lingering interactive prompts.
+* Fixing placeholder file detection to ignore NTFS Zone and DLP streams for
+  file disk size calculation. This is primarily used in verification tests.
 
 Version [1.29.2.0]
 * Replacing authentication for public driver codesign from Hardware Development 

--- a/source/P4VFS.Console/P4VFS.Notes.txt
+++ b/source/P4VFS.Console/P4VFS.Notes.txt
@@ -11,6 +11,9 @@ Version [1.29.3.0]
   termination. This offers safety from possible lingering interactive prompts.
 * Fixing placeholder file detection to ignore NTFS Zone and DLP streams for
   file disk size calculation. This is primarily used in verification tests.
+* Addition of ShellLoginTimeoutTest with simulation of Perforce server extension
+  similar to Helix Authentication Service for testing response to sso-auth-check
+  challenge from URL
 
 Version [1.29.2.0]
 * Replacing authentication for public driver codesign from Hardware Development 

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -1044,9 +1044,11 @@ Available commands:
 			if (String.IsNullOrEmpty(shellUrl) == false)
 			{
 				VirtualFileSystemLog.Info("Login from URL: {0}", shellUrl);
-				ProcessInfo.ExecuteResult executeResult = ProcessInfo.ExecuteWait(new ProcessInfo.ExecuteParams {
+				ProcessInfo.ExecuteResult executeResult = ProcessInfo.ExecuteWait(new ProcessInfo.ExecuteParams{
 					FileName = shellUrl,
 					UseShell = true,
+					LogOutput = false,
+					LogCommand = false,
 					CancellationToken = cancellationToken
 				});
 				if (executeResult.WasCanceled)

--- a/source/P4VFS.Console/Source/Program.cs
+++ b/source/P4VFS.Console/Source/Program.cs
@@ -57,6 +57,8 @@ Available commands:
   info        Print out client/server information
   set         Modify current service settings temporarily for this login session. 
   resident    Modify current resident status of local files.
+  hydrate     Change file status to resident state (full downloaded size).
+  dehydrate   Change file status to virtual state (zero downloaded size).
   populate    Perform sync as fast as possible using quiet, single flush
   reconfig    Modify the perforce configuration of local placeholder files.
   monitor     Launch and control the P4VFS monitor application.
@@ -207,10 +209,12 @@ Available commands:
 {"login", @"
   login       Login to the perforce server and update the current ticket.
 
-              p4vfs login [-i -w] [password]
+              p4vfs login [-i -w] [-u <url>] [-t <seconds>] [password]
 
    -i         Display a modal dialog for password entry
    -w         Write the password to stdout after entering
+   -u         Open a browser window with login challenge URL
+   -t         Timeout waiting for login to complete
 "},
 
 {"test", @"

--- a/source/P4VFS.Core/Include/FileOperations.h
+++ b/source/P4VFS.Core/Include/FileOperations.h
@@ -239,7 +239,7 @@ namespace FileOperations {
 	CreateProcessImpersonated(
 		const WCHAR* commandLine,
 		const WCHAR* currentDirectory,
-		BOOL waitForExit,
+		FileCore::Process::ExecuteFlags::Enum flags,
 		FileCore::String* stdOutput = nullptr,
 		const FileCore::UserContext* context = nullptr
 		);

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -292,7 +292,7 @@ public:
 		{
 			UserContext* context = m_Client->GetUserContext();
 			WString cmd = StringInfo::Format(L"\"%s\\p4vfs.exe\" %s login -t 60 -u \"%s\"", FileInfo::FolderPath(FileInfo::ApplicationFilePath().c_str()).c_str(), CSTR_ATOW(m_Client->Config().ToCommandString()), CSTR_ATOW(url->Text()));
-			Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::HideWindow | Process::ExecuteFlags::Unelevated;
+			Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::HideWindow;
 			FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, flags, nullptr, context);
 		}
 	}
@@ -976,7 +976,7 @@ bool FDepotClient::RequestInteractivePassword(DepotString& passwd)
 	WString output;
 	UserContext* context = m_P4->m_FileContext ? m_P4->m_FileContext->m_UserContext : nullptr;
 	WString cmd = StringInfo::Format(L"\"%s\\p4vfs.exe\" %s login -i -w", FileInfo::FolderPath(FileInfo::ApplicationFilePath().c_str()).c_str(), CSTR_ATOW(m_P4->m_Config.ToCommandString()));
-	Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::WaitForExit | Process::ExecuteFlags::HideWindow | Process::ExecuteFlags::Unelevated;
+	Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::WaitForExit | Process::ExecuteFlags::HideWindow;
 	if (SUCCEEDED(FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, flags, &output, context)))
 	{
 		WStringArray lines = StringInfo::Split(output.c_str(), L"\n\r", StringInfo::SplitFlags::RemoveEmptyEntries);

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -292,7 +292,8 @@ public:
 		{
 			UserContext* context = m_Client->GetUserContext();
 			WString cmd = StringInfo::Format(L"\"%s\\p4vfs.exe\" %s login -t 60 -u \"%s\"", FileInfo::FolderPath(FileInfo::ApplicationFilePath().c_str()).c_str(), CSTR_ATOW(m_Client->Config().ToCommandString()), CSTR_ATOW(url->Text()));
-			FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, FALSE, nullptr, context);
+			Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::HideWindow | Process::ExecuteFlags::Unelevated;
+			FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, flags, nullptr, context);
 		}
 	}
 
@@ -975,7 +976,8 @@ bool FDepotClient::RequestInteractivePassword(DepotString& passwd)
 	WString output;
 	UserContext* context = m_P4->m_FileContext ? m_P4->m_FileContext->m_UserContext : nullptr;
 	WString cmd = StringInfo::Format(L"\"%s\\p4vfs.exe\" %s login -i -w", FileInfo::FolderPath(FileInfo::ApplicationFilePath().c_str()).c_str(), CSTR_ATOW(m_P4->m_Config.ToCommandString()));
-	if (SUCCEEDED(FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, TRUE, &output, context)))
+	Process::ExecuteFlags::Enum flags = Process::ExecuteFlags::WaitForExit | Process::ExecuteFlags::HideWindow | Process::ExecuteFlags::Unelevated;
+	if (SUCCEEDED(FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, flags, &output, context)))
 	{
 		WStringArray lines = StringInfo::Split(output.c_str(), L"\n\r", StringInfo::SplitFlags::RemoveEmptyEntries);
 		for (const WString& line : lines)

--- a/source/P4VFS.Core/Source/DepotClient.cpp
+++ b/source/P4VFS.Core/Source/DepotClient.cpp
@@ -291,8 +291,8 @@ public:
 		if (url != nullptr && FileCore::StringInfo::IsNullOrEmpty(url->Text()) == false)
 		{
 			UserContext* context = m_Client->GetUserContext();
-			DepotString cmd = StringInfo::Format("cmd.exe /c start %s", url->Text());
-			FileOperations::CreateProcessImpersonated(CSTR_ATOW(cmd), nullptr, FALSE, nullptr, context);
+			WString cmd = StringInfo::Format(L"\"%s\\p4vfs.exe\" %s login -t 60 -u \"%s\"", FileInfo::FolderPath(FileInfo::ApplicationFilePath().c_str()).c_str(), CSTR_ATOW(m_Client->Config().ToCommandString()), CSTR_ATOW(url->Text()));
+			FileOperations::CreateProcessImpersonated(cmd.c_str(), nullptr, FALSE, nullptr, context);
 		}
 	}
 

--- a/source/P4VFS.Core/Source/FileOperations.cpp
+++ b/source/P4VFS.Core/Source/FileOperations.cpp
@@ -1687,7 +1687,7 @@ HRESULT
 CreateProcessImpersonated(
 	const WCHAR* commandLine,
 	const WCHAR* currentDirectory,
-	BOOL waitForExit,
+	FileCore::Process::ExecuteFlags::Enum flags,
 	FileCore::String* stdOutput,
 	const FileCore::UserContext* context
 	)
@@ -1703,11 +1703,6 @@ CreateProcessImpersonated(
 		return HRESULT_FROM_WIN32(ERROR_INVALID_TOKEN);
 	}
 
-	FileCore::Process::ExecuteFlags::Enum flags = FileCore::Process::ExecuteFlags::HideWindow;
-	if (waitForExit)
-	{
-		flags |= FileCore::Process::ExecuteFlags::WaitForExit;
-	}
 	if (stdOutput != nullptr)
 	{
 		flags |= FileCore::Process::ExecuteFlags::StdOut;

--- a/source/P4VFS.Core/Source/FileOperations.cpp
+++ b/source/P4VFS.Core/Source/FileOperations.cpp
@@ -5,7 +5,6 @@
 #include "FileCore.h"
 #include "FileAssert.h"
 #include "SettingManager.h"
-#include <shellapi.h>
 
 namespace Microsoft {
 namespace P4VFS {
@@ -1714,37 +1713,6 @@ CreateProcessImpersonated(
 		stdOutput->assign(FileCore::StringInfo::ToWide(result.m_StdOut));
 	}
 	return result.m_HR;
-}
-
-HRESULT 
-ShellExecuteImpersonated(
-	HWND hWnd,
-	const wchar_t* lpOperation,
-	const wchar_t* lpFile,
-	const wchar_t* lpParameters,
-	const wchar_t* lpDirectory,
-	INT nShowCmd,
-	const FileCore::UserContext* context
-	)
-{
-	auto shellexec = [&]() -> HRESULT
-	{
-		HINSTANCE result = ShellExecuteW(hWnd, lpOperation, lpFile, lpParameters, lpDirectory, nShowCmd);
-		return reinterpret_cast<INT_PTR>(result) > 32 ? S_OK : HRESULT_FROM_WIN32(GetLastError());
-	};
-
-	HRESULT hr = E_FAIL;
-	if (context == nullptr || IsSystemUserContext(context))
-	{
-		hr = shellexec();
-	}
-	else if (SUCCEEDED(ImpersonateLoggedOnUser(context)))
-	{
-		hr = shellexec();
-		::RevertToSelf();
-	}
-	
-	return hr;
 }
 
 HRESULT

--- a/source/P4VFS.CoreInterop/Include/CoreInterop.h
+++ b/source/P4VFS.CoreInterop/Include/CoreInterop.h
@@ -131,6 +131,18 @@ public:
 		);
 };
 
+[System::FlagsAttribute]
+public enum class ProcessExecuteFlags : System::Int32
+{
+	None		= FileCore::Process::ExecuteFlags::None,
+	WaitForExit	= FileCore::Process::ExecuteFlags::WaitForExit,
+	HideWindow	= FileCore::Process::ExecuteFlags::HideWindow,
+	StdOut		= FileCore::Process::ExecuteFlags::StdOut,
+	KeepOpen	= FileCore::Process::ExecuteFlags::KeepOpen,
+	Unelevated	= FileCore::Process::ExecuteFlags::Unelevated,
+	Default		= FileCore::Process::ExecuteFlags::Default,
+};
+
 public ref class NativeMethods abstract sealed
 {
 public:
@@ -219,7 +231,7 @@ public:
 	CreateProcessImpersonated(
 		System::String^ commandLine,
 		System::String^ currentDirectory,
-		System::Boolean waitForExit,
+		ProcessExecuteFlags flags,
 		System::Text::StringBuilder^ stdOutput,
 		UserContext^ context
 		);

--- a/source/P4VFS.CoreInterop/Source/CoreInterop.cpp
+++ b/source/P4VFS.CoreInterop/Source/CoreInterop.cpp
@@ -325,7 +325,7 @@ System::Boolean
 NativeMethods::CreateProcessImpersonated(
 	System::String^ commandLine,
 	System::String^ currentDirectory,
-	System::Boolean waitForExit,
+	ProcessExecuteFlags flags,
 	System::Text::StringBuilder^ stdOutput,
 	UserContext^ context
 	)
@@ -334,7 +334,7 @@ NativeMethods::CreateProcessImpersonated(
 	HRESULT status = FileOperations::CreateProcessImpersonated(
 										marshal_as_wstring_c_str(commandLine), 
 										marshal_as_wstring_c_str(currentDirectory), 
-										waitForExit,
+										static_cast<FileCore::Process::ExecuteFlags::Enum>(flags),
 										stdOutput != nullptr ? &stdOutputResult : nullptr,
 										marshal_as_user_context(context)
 										);

--- a/source/P4VFS.Extensions/Source/Controls/LoginWindow.xaml.cs
+++ b/source/P4VFS.Extensions/Source/Controls/LoginWindow.xaml.cs
@@ -3,28 +3,28 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Xml;
-using System.Threading.Tasks;
+using System.Threading;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+using System.Windows.Threading;
 
 namespace Microsoft.P4VFS.Extensions.Controls
 {
 	public partial class LoginWindow : Window
 	{
+		private CancellationToken? m_CancellationToken;
+		private DispatcherTimer m_UpdateTimer; 
+
 		public LoginWindow()
 		{
 			InitializeComponent();
+
+			m_UpdateTimer = new DispatcherTimer();
+			m_UpdateTimer.Interval = TimeSpan.FromSeconds(1.0/30.0);
+			m_UpdateTimer.Tick += OnTickUpdateTimer;
+			m_UpdateTimer.Start();
 		}
 
-        public string Port
+		public string Port
 		{
 			get { return m_Port.Text; }
 			set { m_Port.Text = value; }
@@ -47,6 +47,20 @@ namespace Microsoft.P4VFS.Extensions.Controls
 			get { return m_Passwd.Password; }
 			set { m_Passwd.Password = value; }
 		}
+
+		public CancellationToken? CancellationToken
+		{
+			get { return m_CancellationToken; }
+			set { m_CancellationToken = value; }
+		}
+
+		private void OnTickUpdateTimer(object sender, EventArgs e)
+		{
+			if (m_CancellationToken?.IsCancellationRequested == true)
+			{
+				this.DialogResult = false;
+			}
+		}		
 
 		private void OnClickButtonCancel(object sender, RoutedEventArgs e)
 		{

--- a/source/P4VFS.Extensions/Source/Utilities/ConsoleReader.cs
+++ b/source/P4VFS.Extensions/Source/Utilities/ConsoleReader.cs
@@ -5,188 +5,186 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security;
 using System.Text;
+using System.Threading;
 
 namespace Microsoft.P4VFS.Extensions.Utilities
 {
-    public static class ConsoleReader
-    {
-        private const char MaskCharacter = '*';
+	public static class ConsoleReader
+	{
+		private const char MaskCharacter = '*';
 
-        /// <summary>
-        /// Reads a single line of text from the system console,
-        /// masking the typed characters.
-        /// </summary>
-        public static string ReadLine()
-        {
-            StringBuilder buffer = new StringBuilder(64);
-            ReadLine(new StringBuffer(buffer), MaskCharacter);
-            return buffer.ToString();
-        }
+		/// <summary>
+		/// Reads a single line of text from the system console,
+		/// masking the typed characters.
+		/// </summary>
+		public static string ReadLine(CancellationToken cancellationToken = default)
+		{
+			StringBuilder buffer = new StringBuilder(64);
+			ReadLine(new StringBuffer(buffer), MaskCharacter, cancellationToken);
+			return buffer.ToString();
+		}
 
-        /// <summary>
-        /// Reads a single line of text from the system console as a
-        /// <c>SecureString</c> instance, masking the typed
-        /// characters.
-        /// </summary>
-        /// <remarks>
-        /// The caller is responsible for freeing the returned string
-        /// after usage by calling its <c>Dispose()</c> method.
-        /// </remarks>
-        public static SecureString ReadSecureLine()
-        {
-            SecureString secureString = null;
-            try
-            {
-                secureString = new SecureString();
-                ReadLine(new SecureStringBuffer(secureString), MaskCharacter);
-                secureString.MakeReadOnly();
-                return secureString;
-            }
-            catch
-            {
-                if (secureString != null)
-                {
-                    secureString.Dispose();
-                }
-                throw;
-            }
-        }
+		/// <summary>
+		/// Reads a single line of text from the system console as a
+		/// <c>SecureString</c> instance, masking the typed
+		/// characters.
+		/// </summary>
+		/// <remarks>
+		/// The caller is responsible for freeing the returned string
+		/// after usage by calling its <c>Dispose()</c> method.
+		/// </remarks>
+		public static SecureString ReadSecureLine(CancellationToken cancellationToken = default)
+		{
+			SecureString secureString = null;
+			try
+			{
+				secureString = new SecureString();
+				ReadLine(new SecureStringBuffer(secureString), MaskCharacter, cancellationToken);
+				secureString.MakeReadOnly();
+				return secureString;
+			}
+			catch
+			{
+				if (secureString != null)
+				{
+					secureString.Dispose();
+				}
+				throw;
+			}
+		}
 
-        private static void ReadLine(IBuffer buffer, char maskChar)
-        {
-            int startPosition = Console.CursorLeft;
+		private static void ReadLine(IBuffer buffer, char maskChar, CancellationToken cancellationToken = default)
+		{
+			int startPosition = Console.CursorLeft;
+			int position = 0;
+			int length = 0;
 
-            int position = 0;
-            int length = 0;
+			ConsoleKeyInfo keyInfo;
+			while ((keyInfo = Console.ReadKey(true)).Key != ConsoleKey.Enter)
+			{
+				if (keyInfo.Key == ConsoleKey.Backspace)
+				{
+					if (position > 0)
+					{
+						buffer.DeleteChar(--position);
+						Write(startPosition + --length, ' ');
+					}
+				}
+				else if (keyInfo.Key == ConsoleKey.UpArrow ||
+						 keyInfo.Key == ConsoleKey.PageUp ||
+						 keyInfo.Key == ConsoleKey.Escape)
+				{
+					// Match buffer-empty 'doskey' scenario for up arrow & page up.
+					buffer.Clear();
+					for (; length >= 0; length--)
+					{
+						Write(startPosition + length, ' ');
+					}
+					position = length = 0;
+				}
+				else if (keyInfo.Key == ConsoleKey.DownArrow ||
+						 keyInfo.Key == ConsoleKey.PageDown)
+				{
+				}
+				else if (keyInfo.Key == ConsoleKey.LeftArrow)
+				{
+					position = Math.Max(position - 1, 0);
+				}
+				else if (keyInfo.Key == ConsoleKey.RightArrow)
+				{
+					position = Math.Min(position + 1, length);
+				}
+				else if (keyInfo.Key == ConsoleKey.Delete)
+				{
+					if (position < length)
+					{
+						buffer.DeleteChar(position);
+						Write(startPosition + --length, ' ');
+					}
+				}
+				else if (keyInfo.Key == ConsoleKey.Home)
+				{
+					position = 0;
+				}
+				else if (keyInfo.Key == ConsoleKey.End)
+				{
+					position = length;
+				}
+				else
+				{
+					buffer.InsertChar(position, keyInfo.KeyChar);
+					position++;
+					Write(startPosition + length, maskChar);
+					length++;
+				}
 
-            ConsoleKeyInfo keyInfo;
-            while ((keyInfo = Console.ReadKey(true)).Key != ConsoleKey.Enter)
-            {
-                if (keyInfo.Key == ConsoleKey.Backspace)
-                {
-                    if (position > 0)
-                    {
-                        buffer.DeleteChar(--position);
-                        Write(startPosition + --length, ' ');
-                    }
-                }
-                else if (keyInfo.Key == ConsoleKey.UpArrow ||
-                           keyInfo.Key == ConsoleKey.PageUp ||
-                           keyInfo.Key == ConsoleKey.Escape)
-                {
-                    // Match buffer-empty 'doskey' scenario for up
-                    // arrow & page up.
-                    buffer.Clear();
-                    for (; length >= 0; length--)
-                    {
-                        Write(startPosition + length, ' ');
-                    }
-                    position = length = 0;
-                }
-                else if (keyInfo.Key == ConsoleKey.DownArrow ||
-                         keyInfo.Key == ConsoleKey.PageDown)
-                {
-                    // No-op.
-                }
-                else if (keyInfo.Key == ConsoleKey.LeftArrow)
-                {
-                    position = Math.Max(position - 1, 0);
-                }
-                else if (keyInfo.Key == ConsoleKey.RightArrow)
-                {
-                    position = Math.Min(position + 1, length);
-                }
-                else if (keyInfo.Key == ConsoleKey.Delete)
-                {
-                    if (position < length)
-                    {
-                        buffer.DeleteChar(position);
-                        Write(startPosition + --length, ' ');
-                    }
-                }
-                else if (keyInfo.Key == ConsoleKey.Home)
-                {
-                    position = 0;
-                }
-                else if (keyInfo.Key == ConsoleKey.End)
-                {
-                    position = length;
-                }
-                else
-                {
-                    buffer.InsertChar(position, keyInfo.KeyChar);
-                    position++;
-                    Write(startPosition + length, maskChar);
-                    length++;
-                }
+				Console.CursorLeft = position + startPosition;
+			}
 
-                Console.CursorLeft = position + startPosition;
-            }
+			Console.WriteLine();
+		}
 
-            Console.WriteLine();
-        }
+		private static void Write(int index, char c)
+		{
+			Console.CursorLeft = index;
+			Console.Write(c);
+		}
 
-        private static void Write(int index, char c)
-        {
-            Console.CursorLeft = index;
-            Console.Write(c);
-        }
+		private interface IBuffer
+		{
+			void InsertChar(int index, char c);
+			void DeleteChar(int index);
+			void Clear();
+		}
 
-        private interface IBuffer
-        {
-            void InsertChar(int index, char c);
-            void DeleteChar(int index);
-            void Clear();
-        }
+		private class StringBuffer : IBuffer
+		{
+			private StringBuilder buffer;
 
-        private class StringBuffer : IBuffer
-        {
-            private StringBuilder buffer;
+			public StringBuffer(StringBuilder buffer)
+			{
+				this.buffer = buffer;
+			}
 
-            public StringBuffer(StringBuilder buffer)
-            {
-                this.buffer = buffer;
-            }
+			public void InsertChar(int index, char c)
+			{
+				this.buffer.Insert(index, c);
+			}
 
-            public void InsertChar(int index, char c)
-            {
-                this.buffer.Insert(index, c);
-            }
+			public void DeleteChar(int index)
+			{
+				buffer.Remove(index, 1);
+			}
 
-            public void DeleteChar(int index)
-            {
-                buffer.Remove(index, 1);
-            }
+			public void Clear()
+			{
+				this.buffer.Length = 0;
+			}
+		}
 
-            public void Clear()
-            {
-                this.buffer.Length = 0;
-            }
-        }
+		private class SecureStringBuffer : IBuffer
+		{
+			private SecureString buffer;
 
-        private class SecureStringBuffer : IBuffer
-        {
-            private SecureString buffer;
+			public SecureStringBuffer(SecureString buffer)
+			{
+				this.buffer = buffer;
+			}
 
-            public SecureStringBuffer(SecureString buffer)
-            {
-                this.buffer = buffer;
-            }
+			public void InsertChar(int index, char c)
+			{
+				this.buffer.InsertAt(index, c);
+			}
 
-            public void InsertChar(int index, char c)
-            {
-                this.buffer.InsertAt(index, c);
-            }
+			public void DeleteChar(int index)
+			{
+				this.buffer.RemoveAt(index);
+			}
 
-            public void DeleteChar(int index)
-            {
-                this.buffer.RemoveAt(index);
-            }
-
-            public void Clear()
-            {
-                this.buffer.Clear();
-            }
-        }
-    }
+			public void Clear()
+			{
+				this.buffer.Clear();
+			}
+		}
+	}
 }

--- a/source/P4VFS.UnitTest/Source/UnitTestBase.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestBase.cs
@@ -336,6 +336,8 @@ namespace Microsoft.P4VFS.UnitTest
 				Assert(workspace.LineEnd == DepotResultClient.LineEnd.Local);
 				Assert(workspace.Client != _P4Client || workspace.View.Count() == 1);
 				Assert(workspace.Client != _P4Client || workspace.View.ElementAt(0) == String.Format("//depot/... //{0}/depot/...", workspace.Client));
+				
+				UnitTestServer.ServerUninstallExtentions(config.Port);
 			}
 
 			Extensions.SocketModel.SocketModelClient service = new Extensions.SocketModel.SocketModelClient(); 
@@ -459,7 +461,7 @@ namespace Microsoft.P4VFS.UnitTest
 			return folderPath;
 		}
 
-		public DepotConfig ClientConfig
+		public static DepotConfig ClientConfig
 		{
 			get { return new DepotConfig(){ Port = _P4Port, Client = _P4Client, User = _P4User }; }
 		}

--- a/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
+++ b/source/P4VFS.UnitTest/Source/UnitTestCommon.cs
@@ -441,19 +441,19 @@ namespace Microsoft.P4VFS.UnitTest
 			{
 				System.Text.StringBuilder output = new System.Text.StringBuilder();
 				string cmd = String.Format("\"{0}\\p4vfs.exe\" {1} login -w _incorrect_password_", System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), ClientConfig);
-				Assert(NativeMethods.CreateProcessImpersonated(cmd, null, true, output, null));
+				Assert(NativeMethods.CreateProcessImpersonated(cmd, null, ProcessExecuteFlags.WaitForExit, output, null));
 				Assert(output.ToString().Split(new char[]{'\n','\r'}, StringSplitOptions.RemoveEmptyEntries).Contains("Login failed."));
 			}
 			{
 				System.Text.StringBuilder output = new System.Text.StringBuilder();
 				string cmd = String.Format("cmd.exe /s /c echo foobar");
-				Assert(NativeMethods.CreateProcessImpersonated(cmd, null, true, output, null));
+				Assert(NativeMethods.CreateProcessImpersonated(cmd, null, ProcessExecuteFlags.WaitForExit, output, null));
 				Assert(output.ToString().Split(new char[]{'\n','\r'}, StringSplitOptions.RemoveEmptyEntries).Contains("foobar"));
 			}
 			{
 				System.Text.StringBuilder output = new System.Text.StringBuilder();
 				string cmd = String.Format("cmd.exe /s /c");
-				Assert(NativeMethods.CreateProcessImpersonated(cmd, null, true, output, null));
+				Assert(NativeMethods.CreateProcessImpersonated(cmd, null, ProcessExecuteFlags.WaitForExit, output, null));
 				Assert(output.ToString().Length == 0);
 			}
 		}


### PR DESCRIPTION
Version [1.29.3.0]
* Perforce SSO login from URL now uses impersonated p4vfs login command and ShellExecute 
  instead of using cmd.exe. This fixes rare case lingering cmd.exe processes from failed 
  launch of the browser when there's no desktop session. This also prevents cmd.exe 
  with inherited handles, including TCP ports, from remaining open after service
  is stopped and possibly causing failed port reopening after reinstall.
* Added option 'login -u <url>' for handling login challenge in web browser
* Added option 'login -t <seconds>' for timeout of login command before self
  termination. This offers safety from possible lingering interactive prompts.
* Fixing placeholder file detection to ignore NTFS Zone and DLP streams for
  file disk size calculation. This is primarily used in verification tests.